### PR TITLE
Add perioperative observation table and visualization

### DIFF
--- a/src/database/functions.py
+++ b/src/database/functions.py
@@ -6,6 +6,7 @@ from database.schemas.lee import LeeRcriRead, LeeRcriInput, LeeRcriUpdate
 from database.schemas.persons import PersonCreate, PersonRead, PersonUpdate
 from database.schemas.soba import SobaRead, SobaCreate, SobaUpdate
 from database.schemas.stopbang import StopBangRead, StopBangInput
+from database.schemas.operation import OperationDataInput, OperationDataRead
 from database.services.ariscat import AriscatService
 from database.services.caprini import CapriniService
 from database.services.elganzouri import ElGanzouriService
@@ -13,6 +14,7 @@ from database.services.lee import LeeRcriService
 from database.services.persons import PersonsService
 from database.services.soba import SobaService
 from database.services.stopbang import StopBangService
+from database.services.operation import OperationDataService
 from database.services.utils import NotFoundError
 
 
@@ -169,4 +171,16 @@ def caprini_clear_result(person_id: int) -> bool:
     with SessionLocal() as session:
         svc = CapriniService(session)
         return svc.clear_result(person_id)
+
+
+def op_add_measure(person_id: int, data: OperationDataInput) -> OperationDataRead:
+    with SessionLocal() as session:
+        svc = OperationDataService(session)
+        return svc.add_measure(person_id, data)
+
+
+def op_get_measures(person_id: int) -> list[OperationDataRead]:
+    with SessionLocal() as session:
+        svc = OperationDataService(session)
+        return svc.list_measures(person_id)
 

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -33,6 +33,12 @@ class Person(Base):
         cascade="all, delete-orphan",
     )
 
+    operation_data = relationship(
+        "OperationData",
+        back_populates="person",
+        cascade="all, delete-orphan",
+    )
+
     def __repr__(self):
         sex = "Ж" if self.gender else "М"
         return (
@@ -384,3 +390,21 @@ class CapriniResult(Base):
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
     scales = relationship("PersonScales", back_populates="caprini")
+
+
+class OperationData(Base):
+    __tablename__ = "operation_data"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    person_id = Column(Integer, ForeignKey("persons.id", ondelete="CASCADE"), nullable=False, index=True)
+    point = Column(String(3), nullable=False)  # T0..T12
+    name = Column(String(255), nullable=False)
+    value = Column(Float, nullable=True)
+    unit = Column(String(32), nullable=True)
+    min_value = Column(Float, nullable=True)
+    max_value = Column(Float, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    person = relationship("Person", back_populates="operation_data")

--- a/src/database/repositories/operation.py
+++ b/src/database/repositories/operation.py
@@ -1,0 +1,22 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import select, delete
+
+from database.models import OperationData
+
+
+class OperationDataRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list_for_person(self, person_id: int) -> list[OperationData]:
+        stmt = select(OperationData).where(OperationData.person_id == person_id)
+        return list(self.session.execute(stmt).scalars().all())
+
+    def add(self, obj: OperationData) -> OperationData:
+        self.session.add(obj)
+        return obj
+
+    def delete_for_person(self, person_id: int) -> int:
+        stmt = delete(OperationData).where(OperationData.person_id == person_id)
+        res = self.session.execute(stmt)
+        return res.rowcount or 0

--- a/src/database/schemas/operation.py
+++ b/src/database/schemas/operation.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class OperationDataInput(BaseModel):
+    point: str
+    name: str
+    value: float | None = None
+    unit: str | None = None
+    min_value: float | None = None
+    max_value: float | None = None
+
+
+class OperationDataRead(OperationDataInput):
+    id: int
+    person_id: int
+
+    class Config:
+        from_attributes = True

--- a/src/database/services/operation.py
+++ b/src/database/services/operation.py
@@ -1,0 +1,27 @@
+from sqlalchemy.orm import Session
+
+from database.models import OperationData
+from database.repositories.operation import OperationDataRepository
+from database.schemas.operation import OperationDataInput, OperationDataRead
+
+
+class OperationDataService:
+    def __init__(self, session: Session):
+        self.session = session
+        self.repo = OperationDataRepository(session)
+
+    def add_measure(self, person_id: int, data: OperationDataInput) -> OperationDataRead:
+        obj = OperationData(person_id=person_id, **data.model_dump())
+        self.repo.add(obj)
+        self.session.commit()
+        self.session.refresh(obj)
+        return OperationDataRead.model_validate(obj)
+
+    def list_measures(self, person_id: int) -> list[OperationDataRead]:
+        objs = self.repo.list_for_person(person_id)
+        return [OperationDataRead.model_validate(o) for o in objs]
+
+    def clear_person(self, person_id: int) -> int:
+        count = self.repo.delete_for_person(person_id)
+        self.session.commit()
+        return count

--- a/src/frontend/operation.py
+++ b/src/frontend/operation.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import streamlit as st
+
+from database.functions import op_get_measures
+from frontend.general import create_big_button
+from frontend.utils import change_menu_item
+
+OPERATION_POINTS = [f"T{i}" for i in range(0, 9)]  # T0-T8
+POSTOP_POINTS = [f"T{i}" for i in range(9, 13)]  # T9-T12
+
+
+def _pivot(measures, points):
+    rows = [m.model_dump() for m in measures if m.point in points]
+    if not rows:
+        return None
+    df = pd.DataFrame(rows)
+    pivot = df.pivot_table(index="name", columns="point", values="value", aggfunc="first")
+    pivot = pivot.sort_index(axis=1)
+    return pivot
+
+
+def show_operation():
+    person_id = st.session_state.get("current_patient_id")
+    measures = op_get_measures(person_id)
+    st.title("🧪 Операция")
+    table = _pivot(measures, OPERATION_POINTS)
+    if table is None:
+        st.info("Нет данных.")
+    else:
+        st.dataframe(table)
+    create_big_button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "diagnosis_patient"}, icon="⬅️")
+
+
+def show_postoperative():
+    person_id = st.session_state.get("current_patient_id")
+    measures = op_get_measures(person_id)
+    st.title("🏥 Послеоперационный период")
+    table = _pivot(measures, POSTOP_POINTS)
+    if table is None:
+        st.info("Нет данных.")
+    else:
+        st.dataframe(table)
+    create_big_button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "diagnosis_patient"}, icon="⬅️")

--- a/src/frontend/patient.py
+++ b/src/frontend/patient.py
@@ -16,13 +16,21 @@ def show_diagnosis_patient():
         on_click=change_menu_item,
         kwargs={"item": "preoperative_exam"},
         icon="👁️")
-    create_big_button("Операция", icon="🧪")
+    create_big_button(
+        "Операция",
+        on_click=change_menu_item,
+        kwargs={"item": "operation"},
+        icon="🧪")
     create_big_button(
         "Послеоперационный период",
-        on_click="export_patient_data",
-        kwargs={"item": "export_patient_data"},
+        on_click=change_menu_item,
+        kwargs={"item": "postoperative_period"},
         icon="🏥")
-    create_big_button("Выгрузить данные пациента", icon="📤")
+    create_big_button(
+        "Выгрузить данные пациента",
+        on_click=change_menu_item,
+        kwargs={"item": "export_patient_data"},
+        icon="📤")
     create_big_button("Назад", on_click=change_menu_item, kwargs={"item": "patients"}, icon="⬅️")
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from frontend.scales.lee import show_lee_scale
 from frontend.scales.soba import show_soba_scale
 from frontend.scales.stopbang import show_stopbang_scale
 from frontend.component.loader import export_patient_data
+from frontend.operation import show_operation, show_postoperative
 
 
 menu_items = {
@@ -29,8 +30,8 @@ menu_items = {
     "export_patients": export_patients,
     "diagnosis_patient": show_diagnosis_patient,
     "preoperative_exam": preoperative_exam,
-    "operation": lambda: st.write("Операция"),
-    "postoperative_period": lambda: st.write("Послеоперационный период"),
+    "operation": show_operation,
+    "postoperative_period": show_postoperative,
     "export_patient_data": export_patient_data,
     "show_elganzouri_scale": show_el_ganzouri_form,
     "show_ariscat_scale": show_ariscat_scale,


### PR DESCRIPTION
## Summary
- add `OperationData` model for perioperative measurements and link to patients
- provide repository, service, and functions for storing and retrieving operation data
- implement Streamlit pages for intraoperative and postoperative observation with navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68bc4cbd755483279ae2091bb54cc69c