### PR TITLE
Limit anesthesia type to BOA or OA

### DIFF
--- a/src/database/enums/anesthesia.py
+++ b/src/database/enums/anesthesia.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+class AnesthesiaType(str, Enum):
+    """Типы анестезии."""
+    BOA = "БОА"
+    OA = "ОА"
+

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -16,10 +16,25 @@ from sqlalchemy import (
 from sqlalchemy.sql import func
 from sqlalchemy.ext.hybrid import hybrid_property
 
-from database.enums.ariscat import AriscatAge, AriscatSpO2, AriscatRespInfect, AriscatAnemia, AriscatIncision, \
-    AriscatDuration, AriscatEmergency
-from database.enums.elganzouri import DifficultIntubationHx, WeightBand, MandibleProtrusion, NeckMobility, Mallampati, \
-    Thyromental, MouthOpening
+from database.enums.anesthesia import AnesthesiaType
+from database.enums.ariscat import (
+    AriscatAge,
+    AriscatSpO2,
+    AriscatRespInfect,
+    AriscatAnemia,
+    AriscatIncision,
+    AriscatDuration,
+    AriscatEmergency,
+)
+from database.enums.elganzouri import (
+    DifficultIntubationHx,
+    WeightBand,
+    MandibleProtrusion,
+    NeckMobility,
+    Mallampati,
+    Thyromental,
+    MouthOpening,
+)
 from database.parameters import PARAMETER_KEYS
 
 Base = declarative_base()
@@ -30,7 +45,7 @@ class Person(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
     card_number = Column(String(64), nullable=True)
-    anesthesia_type = Column(String(128), nullable=True)
+    anesthesia_type = Column(SAEnum(AnesthesiaType, name="anesthesia_type"), nullable=True)
     last_name = Column(String(128), nullable=False)
     first_name = Column(String(128), nullable=False)
     patronymic = Column(String(128), nullable=True)

--- a/src/database/schemas/persons.py
+++ b/src/database/schemas/persons.py
@@ -3,13 +3,14 @@ from pydantic import BaseModel, Field
 from typing import Optional
 from datetime import date
 
+from database.enums.anesthesia import AnesthesiaType
 from database.schemas.person_scales import PersonScalesRead
 
 
 # ----- базовые -----
 class PersonBase(BaseModel):
     card_number: Optional[str] = None
-    anesthesia_type: Optional[str] = None
+    anesthesia_type: Optional[AnesthesiaType] = None
     last_name: str
     first_name: str
     patronymic: Optional[str] = None
@@ -26,7 +27,7 @@ class PersonCreate(PersonBase):
 
 class PersonUpdate(BaseModel):
     card_number: Optional[str] = None
-    anesthesia_type: Optional[str] = None
+    anesthesia_type: Optional[AnesthesiaType] = None
     last_name: Optional[str] = None
     first_name: Optional[str] = None
     patronymic: Optional[str] = None

--- a/src/frontend/component/loader.py
+++ b/src/frontend/component/loader.py
@@ -87,6 +87,8 @@ def export_patient_data():
     def g(obj, name, default=None):
         return getattr(obj, name, default) if obj is not None else default
 
+    atype = g(person, "anesthesia_type", None)
+
     row = {
         "patient_id": person.id,
         "№ карты": g(person, "card_number", ""),
@@ -94,7 +96,7 @@ def export_patient_data():
         "Имя": g(person, "first_name", ""),
         "Отчество": g(person, "patronymic", ""),
         "Дата включения": g(person, "inclusion_date", None),
-        "Тип анестезии": g(person, "anesthesia_type", ""),
+        "Тип анестезии": atype.value if atype else "",
         "Возраст (лет)": g(person, "age", None),
         "Рост (см)": g(person, "height", None),
         "Вес (кг)": g(person, "weight", None),

--- a/src/frontend/patient.py
+++ b/src/frontend/patient.py
@@ -39,7 +39,12 @@ def add_patient():
     st.title("➕ Добавление пациента")
     with st.form("add_patient_form"):
         card_number = st.text_input("Номер карты")
-        anesthesia_type = st.text_input("Тип анестезии")
+        anesthesia_type = st.radio(
+            "Тип анестезии",
+            ["БОА", "ОА"],
+            index=0,
+            horizontal=True,
+        )
 
         c1, c2, c3 = st.columns(3)
         with c1:


### PR DESCRIPTION
## Summary
- Restrict anesthesia type entries to an explicit `AnesthesiaType` enum (`БОА`, `ОА`)
- Replace free-text anesthesia field with Streamlit radio options
- Ensure exports output readable anesthesia type values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bc6b45eb1483279c60eb25e576d54d