### PR TITLE
Add postoperative day-one t11 slice

### DIFF
--- a/src/database/functions.py
+++ b/src/database/functions.py
@@ -35,6 +35,8 @@ from database.schemas.slice_t9 import SliceT9Input, SliceT9Read
 from database.services.slice_t9 import SliceT9Service
 from database.schemas.slice_t10 import SliceT10Input, SliceT10Read
 from database.services.slice_t10 import SliceT10Service
+from database.schemas.slice_t11 import SliceT11Input, SliceT11Read
+from database.services.slice_t11 import SliceT11Service
 from database.services.utils import NotFoundError
 
 
@@ -447,3 +449,23 @@ def t10_clear_result(person_id: int) -> bool:
         svc = SliceT10Service(session)
         return svc.delete(person_id)
 
+
+def t11_get_result(person_id: int) -> SliceT11Read | None:
+    with SessionLocal() as session:
+        svc = SliceT11Service(session)
+        try:
+            return svc.get(person_id)
+        except NotFoundError:
+            return None
+
+
+def t11_upsert_result(person_id: int, data: SliceT11Input) -> SliceT11Read:
+    with SessionLocal() as session:
+        svc = SliceT11Service(session)
+        return svc.upsert(person_id, data)
+
+
+def t11_clear_result(person_id: int) -> bool:
+    with SessionLocal() as session:
+        svc = SliceT11Service(session)
+        return svc.delete(person_id)

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -1059,7 +1059,7 @@ class SliceT9(Base):
 
 
 class SliceT10(Base):
-    """Data for slice T10 (end of first postoperative day)."""
+    """Data for slice T11 (end of first postoperative day)."""
 
     __tablename__ = "slice_t10"
     __table_args__ = (UniqueConstraint("slices_id", name="uq_slice_t10_slices"),)
@@ -1151,7 +1151,7 @@ class SliceT10(Base):
 
 
 class SliceT11(Base):
-    """Placeholder table for slice T11 data."""
+    """Data for slice T11 (end of first postoperative day)."""
 
     __tablename__ = "slice_t11"
     __table_args__ = (UniqueConstraint("slices_id", name="uq_slice_t11_slices"),)
@@ -1160,6 +1160,79 @@ class SliceT11(Base):
     slices_id = Column(
         Integer, ForeignKey("person_slices.id", ondelete="CASCADE"), nullable=False, index=True
     )
+
+    date = Column(Date, nullable=True)
+    time = Column(Time, nullable=True)
+    rr_spont = Column(Float, nullable=True)
+    fev1 = Column(Float, nullable=True)
+    fvc = Column(Float, nullable=True)
+    frc = Column(Float, nullable=True)
+    tlc = Column(Float, nullable=True)
+    rv = Column(Float, nullable=True)
+    fev1_fvc = Column(Float, nullable=True)
+    pef = Column(Float, nullable=True)
+    mef25 = Column(Float, nullable=True)
+    mef50 = Column(Float, nullable=True)
+    mef75 = Column(Float, nullable=True)
+    fef25_75 = Column(Float, nullable=True)
+    heart_rate = Column(Float, nullable=True)
+    sbp = Column(Float, nullable=True)
+    dbp = Column(Float, nullable=True)
+    map = Column(Float, nullable=True)
+    spo2 = Column(Float, nullable=True)
+    urine_ml_per_h = Column(Float, nullable=True)
+    hemoglobin = Column(Float, nullable=True)
+    neutrophils = Column(Float, nullable=True)
+    lymphocytes = Column(Float, nullable=True)
+    hematocrit = Column(Float, nullable=True)
+    leukocytes = Column(Float, nullable=True)
+    bands = Column(Float, nullable=True)
+    albumin = Column(Float, nullable=True)
+    creatinine = Column(Float, nullable=True)
+    gfr = Column(Float, nullable=True)
+    nlr = Column(Float, nullable=True)
+    glucose = Column(Float, nullable=True)
+    stroke_volume = Column(Float, nullable=True)
+    cardiac_index = Column(Float, nullable=True)
+    svri = Column(Float, nullable=True)
+    cao = Column(Float, nullable=True)
+    do2 = Column(Float, nullable=True)
+    vbd = Column(Float, nullable=True)
+    uzl_score = Column(Float, nullable=True)
+    ph_arterial = Column(Float, nullable=True)
+    be_arterial = Column(Float, nullable=True)
+    hco3_arterial = Column(Float, nullable=True)
+    lactate_arterial = Column(Float, nullable=True)
+    pao2 = Column(Float, nullable=True)
+    pao2_fio2 = Column(Float, nullable=True)
+    paco2 = Column(Float, nullable=True)
+    sao2 = Column(Float, nullable=True)
+    pin_prick = Column(Boolean, nullable=True)
+    cold_test = Column(Boolean, nullable=True)
+    motor_block = Column(Boolean, nullable=True)
+    polo = Column(Boolean, nullable=True)
+    phrenic_syndrome = Column(Boolean, nullable=True)
+    phrenic_crsh = Column(Boolean, nullable=True)
+    aki = Column(Boolean, nullable=True)
+    complications = Column(String, nullable=True)
+    pain_nrs = Column(Float, nullable=True)
+    pain_nrs_min = Column(Float, nullable=True)
+    pain_nrs_max = Column(Float, nullable=True)
+    nausea_vomiting = Column(Boolean, nullable=True)
+    aldrete_score = Column(Float, nullable=True)
+    aldrete_time = Column(Float, nullable=True)
+    t_activation = Column(Float, nullable=True)
+    t_peristalsis = Column(Float, nullable=True)
+    t_first_gas = Column(Float, nullable=True)
+    opioid_consumption = Column(Float, nullable=True)
+    urinary_catheter_pain = Column(Float, nullable=True)
+    t_in_aro = Column(Float, nullable=True)
+    t_intense_pain = Column(Float, nullable=True)
+    t_restore_frc = Column(Float, nullable=True)
+    t_restore_gfr = Column(Float, nullable=True)
+    t_in_ward = Column(Float, nullable=True)
+    qor15 = Column(Float, nullable=True)
+    satisfied = Column(Boolean, nullable=True)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(

--- a/src/database/repositories/slice_t11.py
+++ b/src/database/repositories/slice_t11.py
@@ -1,0 +1,28 @@
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from database.models import SliceT11
+
+
+class SliceT11Repository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def get_by_slices_id(self, slices_id: int) -> SliceT11 | None:
+        stmt = select(SliceT11).where(SliceT11.slices_id == slices_id)
+        return self.session.execute(stmt).scalar_one_or_none()
+
+    def add(self, obj: SliceT11) -> SliceT11:
+        self.session.add(obj)
+        return obj
+
+    def update_fields(self, obj: SliceT11, **fields) -> SliceT11:
+        for k, v in fields.items():
+            if v is not None:
+                setattr(obj, k, v)
+        return obj
+
+    def delete_by_slices_id(self, slices_id: int) -> int:
+        stmt = delete(SliceT11).where(SliceT11.slices_id == slices_id)
+        res = self.session.execute(stmt)
+        return res.rowcount or 0

--- a/src/database/schemas/slice_t11.py
+++ b/src/database/schemas/slice_t11.py
@@ -1,0 +1,86 @@
+from datetime import date as Date, time as Time
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SliceT11Input(BaseModel):
+    date: Optional[Date] = None
+    time: Optional[Time] = None
+    rr_spont: Optional[float] = None
+    fev1: Optional[float] = None
+    fvc: Optional[float] = None
+    frc: Optional[float] = None
+    tlc: Optional[float] = None
+    rv: Optional[float] = None
+    fev1_fvc: Optional[float] = None
+    pef: Optional[float] = None
+    mef25: Optional[float] = None
+    mef50: Optional[float] = None
+    mef75: Optional[float] = None
+    fef25_75: Optional[float] = None
+    heart_rate: Optional[float] = None
+    sbp: Optional[float] = None
+    dbp: Optional[float] = None
+    map: Optional[float] = None
+    spo2: Optional[float] = None
+    urine_ml_per_h: Optional[float] = None
+    hemoglobin: Optional[float] = None
+    neutrophils: Optional[float] = None
+    lymphocytes: Optional[float] = None
+    hematocrit: Optional[float] = None
+    leukocytes: Optional[float] = None
+    bands: Optional[float] = None
+    albumin: Optional[float] = None
+    creatinine: Optional[float] = None
+    gfr: Optional[float] = None
+    nlr: Optional[float] = None
+    glucose: Optional[float] = None
+    stroke_volume: Optional[float] = None
+    cardiac_index: Optional[float] = None
+    svri: Optional[float] = None
+    cao: Optional[float] = None
+    do2: Optional[float] = None
+    vbd: Optional[float] = None
+    uzl_score: Optional[float] = None
+    ph_arterial: Optional[float] = None
+    be_arterial: Optional[float] = None
+    hco3_arterial: Optional[float] = None
+    lactate_arterial: Optional[float] = None
+    pao2: Optional[float] = None
+    pao2_fio2: Optional[float] = None
+    paco2: Optional[float] = None
+    sao2: Optional[float] = None
+    pin_prick: Optional[bool] = None
+    cold_test: Optional[bool] = None
+    motor_block: Optional[bool] = None
+    polo: Optional[bool] = None
+    phrenic_syndrome: Optional[bool] = None
+    phrenic_crsh: Optional[bool] = None
+    aki: Optional[bool] = None
+    complications: Optional[str] = None
+    pain_nrs: Optional[float] = None
+    pain_nrs_min: Optional[float] = None
+    pain_nrs_max: Optional[float] = None
+    nausea_vomiting: Optional[bool] = None
+    aldrete_score: Optional[float] = None
+    aldrete_time: Optional[float] = None
+    t_activation: Optional[float] = None
+    t_peristalsis: Optional[float] = None
+    t_first_gas: Optional[float] = None
+    opioid_consumption: Optional[float] = None
+    urinary_catheter_pain: Optional[float] = None
+    t_in_aro: Optional[float] = None
+    t_intense_pain: Optional[float] = None
+    t_restore_frc: Optional[float] = None
+    t_restore_gfr: Optional[float] = None
+    t_in_ward: Optional[float] = None
+    qor15: Optional[float] = None
+    satisfied: Optional[bool] = None
+
+
+class SliceT11Read(SliceT11Input):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    slices_id: int

--- a/src/database/services/slice_t11.py
+++ b/src/database/services/slice_t11.py
@@ -1,0 +1,56 @@
+from sqlalchemy.orm import Session
+
+from database.models import PersonSlices, SliceT11
+from database.repositories.person_slices import PersonSlicesRepository
+from database.repositories.slice_t11 import SliceT11Repository
+from database.schemas.slice_t11 import SliceT11Input, SliceT11Read
+from database.services.utils import NotFoundError
+
+
+class SliceT11Service:
+    """CRUD for slice T11 values with flag management."""
+
+    def __init__(self, session: Session):
+        self.session = session
+        self.ps_repo = PersonSlicesRepository(session)
+        self.repo = SliceT11Repository(session)
+
+    def _get_or_create_ps(self, person_id: int) -> PersonSlices:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if ps is None:
+            ps = PersonSlices(person_id=person_id)
+            self.ps_repo.add(ps)
+            self.session.flush()
+        return ps
+
+    def upsert(self, person_id: int, data: SliceT11Input) -> SliceT11Read:
+        ps = self._get_or_create_ps(person_id)
+        obj = self.repo.get_by_slices_id(ps.id)
+        if obj is None:
+            obj = SliceT11(slices_id=ps.id)
+            self.repo.add(obj)
+        self.repo.update_fields(obj, **data.model_dump(exclude_unset=True))
+        self.ps_repo.update_fields(ps, t11_filled=True)
+        self.session.commit()
+        self.session.refresh(obj)
+        self.session.refresh(ps)
+        return SliceT11Read.model_validate(obj)
+
+    def get(self, person_id: int) -> SliceT11Read:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if not ps:
+            raise NotFoundError("PersonSlices not found")
+        obj = self.repo.get_by_slices_id(ps.id)
+        if not obj:
+            raise NotFoundError("SliceT11 not found")
+        return SliceT11Read.model_validate(obj)
+
+    def delete(self, person_id: int) -> bool:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if not ps:
+            raise NotFoundError("PersonSlices not found")
+        affected = self.repo.delete_by_slices_id(ps.id)
+        if affected:
+            self.ps_repo.update_fields(ps, t11_filled=False)
+        self.session.commit()
+        return bool(affected)

--- a/src/frontend/operation.py
+++ b/src/frontend/operation.py
@@ -143,6 +143,7 @@ def show_postoperative():
     slices_status = getattr(person, "slices", None)
     t9_filled = bool(getattr(slices_status, "t9_filled", False)) if slices_status else False
     t10_filled = bool(getattr(slices_status, "t10_filled", False)) if slices_status else False
+    t11_filled = bool(getattr(slices_status, "t11_filled", False)) if slices_status else False
 
     col1, col2 = st.columns([2, 1])
     with col1:
@@ -171,6 +172,20 @@ def show_postoperative():
             icon="📝",
             key="t10_btn",
         )
+    col5, col6 = st.columns([2, 1])
+    with col5:
+        st.markdown(
+            f"**Срез t11 - конец 1-х суток после операции**  \nСтатус: {'✅ Заполнено' if t11_filled else '❌ Не заполнено'}"
+        )
+    with col6:
+        create_big_button(
+            "Перейти",
+            on_click=change_menu_item,
+            kwargs={"item": "show_t11_slice"},
+            icon="📝",
+            key="t11_btn",
+        )
+
 
     _back()
 

--- a/src/frontend/t11.py
+++ b/src/frontend/t11.py
@@ -1,0 +1,131 @@
+from datetime import date, datetime
+
+import streamlit as st
+
+from database.schemas.slice_t11 import SliceT11Input
+from database.functions import t11_get_result, t11_upsert_result, get_person
+from frontend.utils import change_menu_item
+
+
+FIELD_DEFS = [
+    ("date", "Дата", "", "date"),
+    ("time", "Время", "", "time"),
+    ("rr_spont", "ЧД спонтан", "вдох/мин", "float"),
+    ("fev1", "ОФВ1", "л", "float"),
+    ("fvc", "ФЖЕЛ", "л", "float"),
+    ("frc", "ФОЕ", "л", "float"),
+    ("tlc", "ОЕЛ", "л", "float"),
+    ("rv", "ООЛ", "л", "float"),
+    ("fev1_fvc", "ОФВ1/ФЖЕЛ", "%", "float"),
+    ("pef", "ПОС", "л/с", "float"),
+    ("mef25", "МОС25", "л/с", "float"),
+    ("mef50", "МОС50", "л/с", "float"),
+    ("mef75", "МОС75", "л/с", "float"),
+    ("fef25_75", "СОС 25-75", "л/с", "float"),
+    ("heart_rate", "ЧСС", "уд/мин", "float"),
+    ("sbp", "АДсис", "мм рт.ст.", "float"),
+    ("dbp", "АДдиас", "мм рт.ст.", "float"),
+    ("map", "АДср", "мм рт.ст.", "float"),
+    ("spo2", "SpO2", "%", "float"),
+    ("urine_ml_per_h", "Диурез мл/ч", "мл/ч", "float"),
+    ("hemoglobin", "Гемоглобин", "г/л", "float"),
+    ("neutrophils", "Нейтрофилы", "%", "float"),
+    ("lymphocytes", "Лимфоциты", "%", "float"),
+    ("hematocrit", "Гематокрит", "%", "float"),
+    ("leukocytes", "Лейкоциты", "10^9/л", "float"),
+    ("bands", "п/я", "%", "float"),
+    ("albumin", "Альбумин", "г/л", "float"),
+    ("creatinine", "Креатинин", "мкмоль/л", "float"),
+    ("gfr", "СКФ", "мл/мин", "float"),
+    ("nlr", "NLR", "", "float"),
+    ("glucose", "Глюкоза крови", "ммоль/л", "float"),
+    ("stroke_volume", "УО", "мл", "float"),
+    ("cardiac_index", "СИ", "л/мин/м²", "float"),
+    ("svri", "ИОПСС", "дин·с·см⁻⁵·м²", "float"),
+    ("cao", "СаО", "мл/дл", "float"),
+    ("do2", "DO2", "мл/мин", "float"),
+    ("vbd", "ВБД", "", "float"),
+    ("uzl_score", "Балл УЗЛ", "баллы", "float"),
+    ("ph_arterial", "pH артер.", "", "float"),
+    ("be_arterial", "BE артер.", "ммоль/л", "float"),
+    ("hco3_arterial", "HCO3 артер.", "ммоль/л", "float"),
+    ("lactate_arterial", "Лактат артер.", "ммоль/л", "float"),
+    ("pao2", "РаО2", "мм рт.ст.", "float"),
+    ("pao2_fio2", "РаО2/FiO2", "", "float"),
+    ("paco2", "РаСО2", "мм рт.ст.", "float"),
+    ("sao2", "SаO2", "%", "float"),
+    ("pin_prick", "Рin-prick", "", "bool"),
+    ("cold_test", "Cold-test", "", "bool"),
+    ("motor_block", "Моторный блок", "", "bool"),
+    ("polo", "ПОЛО", "", "bool"),
+    ("phrenic_syndrome", "Френикус синд.", "", "bool"),
+    ("phrenic_crsh", "Френикус/ ЦРШ", "", "bool"),
+    ("aki", "ОПП", "", "bool"),
+    ("complications", "Осложнения", "", "str"),
+    ("pain_nrs", "Боль/ ЦРШ", "баллы", "float"),
+    ("pain_nrs_min", "Боль/ ЦРШ Мин", "баллы", "float"),
+    ("pain_nrs_max", "Боль/ ЦРШ Макс", "баллы", "float"),
+    ("nausea_vomiting", "Тошнота/рвота", "", "bool"),
+    ("aldrete_score", "Шкала Aldrete", "баллы", "float"),
+    ("aldrete_time", "Время достижения Aldrete 9-10 б.", "мин", "float"),
+    ("t_activation", "t активизации", "ч", "float"),
+    ("t_peristalsis", "t восс. перистал.", "ч", "float"),
+    ("t_first_gas", "t отхожд. газов", "ч", "float"),
+    ("opioid_consumption", "Расход опиатов", "мг", "float"),
+    ("urinary_catheter_pain", "Боль мочев кат", "баллы", "float"),
+    ("t_in_aro", "t в АРО", "ч", "float"),
+    ("t_intense_pain", "t интенсив. боли", "ч", "float"),
+    ("t_restore_frc", "t восс. ФОЕ", "ч", "float"),
+    ("t_restore_gfr", "t восс. СКФ", "ч", "float"),
+    ("t_in_ward", "t в стационаре", "ч", "float"),
+    ("qor15", "QoR-15", "баллы", "float"),
+    ("satisfied", "Удовлетворен.", "", "bool"),
+]
+
+
+def show_t11_slice():
+    person = st.session_state["current_patient_info"]
+    st.title(f"t11 показатели пациента {person.fio}")
+    st.caption("конец 1-х суток после операции")
+
+    existing = t11_get_result(person.id)
+    defaults = existing.model_dump() if existing else {}
+
+    with st.form("t11_form"):
+        values = {}
+        for i in range(0, len(FIELD_DEFS), 4):
+            cols = st.columns(4)
+            for col, (name, label, placeholder, ftype) in zip(cols, FIELD_DEFS[i:i+4]):
+                default = defaults.get(name)
+                with col:
+                    if ftype == "date":
+                        val = st.date_input(label, value=default or date.today(), key=name)
+                    elif ftype == "time":
+                        val = st.time_input(label, value=default or datetime.now().time(), key=name)
+                    elif ftype == "bool":
+                        val = st.checkbox(label, value=bool(default), key=name)
+                    elif ftype == "str":
+                        val = st.text_input(label, value=default or "", placeholder=placeholder, key=name)
+                    else:
+                        val_str = st.text_input(
+                            label,
+                            value="" if default is None else str(default),
+                            placeholder=placeholder,
+                            key=name,
+                        )
+                        if val_str == "":
+                            val = None
+                        else:
+                            try:
+                                val = float(val_str.replace(',', '.'))
+                            except ValueError:
+                                val = None
+                    values[name] = val
+        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+    if submitted:
+        t11_upsert_result(person.id, SliceT11Input(**values))
+        st.session_state["current_patient_info"] = get_person(person.id)
+        st.success("Данные сохранены")
+        change_menu_item(item="postoperative_period")
+        st.rerun()
+    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "postoperative_period"})

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,7 @@ from frontend.t7 import show_t7_slice
 from frontend.t8 import show_t8_slice
 from frontend.t9 import show_t9_slice
 from frontend.t10 import show_t10_slice
+from frontend.t11 import show_t11_slice
 
 
 menu_items = {
@@ -62,6 +63,7 @@ menu_items = {
     "show_t8_slice": show_t8_slice,
     "show_t9_slice": show_t9_slice,
     "show_t10_slice": show_t10_slice,
+    "show_t11_slice": show_t11_slice,
 }
 
 


### PR DESCRIPTION
## Summary
- add schema, repository and service for new t11 postoperative slice
- store and retrieve t11 data with dedicated functions
- expose t11 slice in UI and application menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68bd86b8bb68832787b9fa01dcb97171