### PR TITLE
feat: export patient data to Excel

### DIFF
--- a/src/frontend/component/loader.py
+++ b/src/frontend/component/loader.py
@@ -1,17 +1,8 @@
-import json
 import io
 import pandas as pd
 import streamlit as st
 
-from database.functions import (
-    get_person,
-    elg_get_result,
-    ar_get_result,
-    sb_get_result,
-    get_soba,
-    rcri_get_result,
-    caprini_get_result,
-)
+import database.functions as db_funcs
 
 
 # ===== helpers =====
@@ -70,18 +61,33 @@ def export_patient_data():
     st.title("📤 Выгрузка данных пациента")
 
     # 1) Берём «свежего» пациента
-    person = _safe(get_person, person_stub.id, label="карточки пациента")
+    person = _safe(db_funcs.get_person, person_stub.id, label="карточки пациента")
     if not person:
         st.error("Не удалось загрузить карточку пациента.")
         return
 
     # 2) Подтягиваем все шкалы (каждый вызов безопасный)
-    elg = _safe(elg_get_result, person.id, label="El-Ganzouri")  # -> ElGanzouriRead | None
-    ar = _safe(ar_get_result, person.id, label="ARISCAT")  # -> AriscatRead | None
-    sb = _safe(sb_get_result, person.id, label="STOP-BANG")  # -> StopBangRead | None
-    soba = _safe(get_soba, person.id, label="SOBA")  # -> SobaRead | None
-    rcri = _safe(rcri_get_result, person.id, label="RCRI")  # -> LeeRcriRead | None
-    cap = _safe(caprini_get_result, person.id, label="Caprini")  # -> CapriniRead | None
+    elg = _safe(db_funcs.elg_get_result, person.id, label="El-Ganzouri")  # -> ElGanzouriRead | None
+    ar = _safe(db_funcs.ar_get_result, person.id, label="ARISCAT")  # -> AriscatRead | None
+    sb = _safe(db_funcs.sb_get_result, person.id, label="STOP-BANG")  # -> StopBangRead | None
+    soba = _safe(db_funcs.get_soba, person.id, label="SOBA")  # -> SobaRead | None
+    rcri = _safe(db_funcs.rcri_get_result, person.id, label="RCRI")  # -> LeeRcriRead | None
+    cap = _safe(db_funcs.caprini_get_result, person.id, label="Caprini")  # -> CapriniRead | None
+
+    # 2b) Подтягиваем все срезы
+    t0 = _safe(db_funcs.t0_get_result, person.id, label="срез T0")
+    t1 = _safe(db_funcs.t1_get_result, person.id, label="срез T1")
+    t2 = _safe(db_funcs.t2_get_result, person.id, label="срез T2")
+    t3 = _safe(db_funcs.t3_get_result, person.id, label="срез T3")
+    t4 = _safe(db_funcs.t4_get_result, person.id, label="срез T4")
+    t5 = _safe(db_funcs.t5_get_result, person.id, label="срез T5")
+    t6 = _safe(db_funcs.t6_get_result, person.id, label="срез T6")
+    t7 = _safe(db_funcs.t7_get_result, person.id, label="срез T7")
+    t8 = _safe(db_funcs.t8_get_result, person.id, label="срез T8")
+    t9 = _safe(db_funcs.t9_get_result, person.id, label="срез T9")
+    t10 = _safe(db_funcs.t10_get_result, person.id, label="срез T10")
+    t11 = _safe(db_funcs.t11_get_result, person.id, label="срез T11")
+    t12 = _safe(db_funcs.t12_get_result, person.id, label="срез T12")
 
     # 3) Собираем одну строку с максимумом защит
     def g(obj, name, default=None):
@@ -133,28 +139,54 @@ def export_patient_data():
         "Caprini: риск": _caprini_label(g(cap, "risk_level", None)),
     }
 
-    # 4) Покажем и дадим скачать
-    df = pd.DataFrame([row])
-    st.markdown("### Предпросмотр")
-    st.dataframe(df, use_container_width=True)
+    # 4) Составляем данные по срезам
 
-    csv_buf = io.StringIO()
-    df.to_csv(csv_buf, index=False)
+    def slice_row(name, data):
+        if not data:
+            return {"slice": name}
+        d = data.model_dump()
+        d.pop("id", None)
+        d.pop("slices_id", None)
+        d["slice"] = name
+        return d
+
+    slice_rows = [
+        slice_row("T0", t0),
+        slice_row("T1", t1),
+        slice_row("T2", t2),
+        slice_row("T3", t3),
+        slice_row("T4", t4),
+        slice_row("T5", t5),
+        slice_row("T6", t6),
+        slice_row("T7", t7),
+        slice_row("T8", t8),
+        slice_row("T9", t9),
+        slice_row("T10", t10),
+        slice_row("T11", t11),
+        slice_row("T12", t12),
+    ]
+
+    # 5) Покажем и дадим скачать
+    df_scales = pd.DataFrame([row])
+    df_slices = pd.DataFrame(slice_rows)
+    st.markdown("### Предпросмотр шкал")
+    st.dataframe(df_scales, width="stretch")
+    st.markdown("### Предпросмотр срезов")
+    st.dataframe(df_slices, width="stretch")
+
+    excel_buf = io.BytesIO()
+    with pd.ExcelWriter(excel_buf) as writer:
+        df_scales.to_excel(writer, index=False, sheet_name="Шкалы")
+        df_slices.to_excel(writer, index=False, sheet_name="Срезы")
+
     st.download_button(
-        "⬇️ Скачать CSV",
-        data=csv_buf.getvalue().encode("utf-8-sig"),
-        file_name=f"patient_{person.id}_export.csv",
-        mime="text/csv",
-        use_container_width=True,
+        "⬇️ Скачать Excel",
+        data=excel_buf.getvalue(),
+        file_name=f"patient_{person.id}_export.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        width="stretch",
     )
 
-    json_str = json.dumps(row, ensure_ascii=False, indent=2)
-    st.download_button(
-        "⬇️ Скачать JSON",
-        data=json_str.encode("utf-8"),
-        file_name=f"patient_{person.id}_export.json",
-        mime="application/json",
-        use_container_width=True,
+    st.caption(
+        "Если какая-то шкала или срез не заполнены, в выгрузке будут пустые значения для их полей."
     )
-
-    st.caption("Если какая-то шкала не заполнена, в выгрузке будут пустые значения для её полей.")

--- a/src/frontend/components.py
+++ b/src/frontend/components.py
@@ -2,4 +2,4 @@ import streamlit as st
 
 
 def create_big_button(label, on_click=None, kwargs=None, icon=None, key=None):
-    st.button(label, on_click=on_click, kwargs=kwargs, use_container_width=True, icon=icon, key=key)
+    st.button(label, on_click=on_click, kwargs=kwargs, width='stretch', icon=icon, key=key)

--- a/src/frontend/patient.py
+++ b/src/frontend/patient.py
@@ -76,7 +76,7 @@ def add_patient():
         except Exception as er:
             print(er)
 
-        submitted = st.form_submit_button("Добавить пациента", use_container_width=True)
+        submitted = st.form_submit_button("Добавить пациента", width='stretch')
 
     if submitted:
         if not last_name.strip() or not first_name.strip():
@@ -111,7 +111,7 @@ def find_patient():
     with st.form("find_patient_form", clear_on_submit=False):
         q = st.text_input("Фамилия (или часть ФИО)", key="patients_find_q",
                           placeholder="Например: Иванов")
-        submitted = st.form_submit_button("Искать", use_container_width=True)
+        submitted = st.form_submit_button("Искать", width='stretch')
 
     # При сабмите — фиксируем запрос и делаем rerun
     if submitted:

--- a/src/frontend/scales/ariscat.py
+++ b/src/frontend/scales/ariscat.py
@@ -109,7 +109,7 @@ def show_ariscat_scale():
 
             emergency = st.checkbox("Экстренная операция", value=bool(defaults["is_emergency"]), key="ar_emerg")
 
-        submitted = st.form_submit_button("💾 Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("💾 Сохранить", width='stretch')
 
     # 4) Сохранение
     if submitted:

--- a/src/frontend/scales/caprini.py
+++ b/src/frontend/scales/caprini.py
@@ -217,7 +217,7 @@ def show_caprini_scale():
             fracture_pelvis_or_limb = st.checkbox("Перелом таза/конечности",
                                                   value=bool(getattr(stored, "fracture_pelvis_or_limb", False)))
 
-        submitted = st.form_submit_button("💾 Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("💾 Сохранить", width='stretch')
 
     if submitted:
         # 1) синхронизация с карточкой пациента (Person)

--- a/src/frontend/scales/elganzouri.py
+++ b/src/frontend/scales/elganzouri.py
@@ -75,7 +75,7 @@ def show_el_ganzouri_form():
             can_protrude = st.checkbox("Выдвижение нижней челюсти возможно", value=bool(defaults["can_protrude"]))
             diff_hx = st.selectbox("Трудная интубация в анамнезе", ["Нет", "Недостоверно", "Определенно"], index=0)
 
-        submitted = st.form_submit_button("💾 Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("💾 Сохранить", width='stretch')
 
     # 3) Сохранение
     if submitted:

--- a/src/frontend/scales/lee.py
+++ b/src/frontend/scales/lee.py
@@ -57,7 +57,7 @@ def show_lee_scale():
                 value=bool(getattr(stored, "creatinine_gt_180_umol_l", False)),
             )
 
-        submitted = st.form_submit_button("💾 Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("💾 Сохранить", width='stretch')
 
     if submitted:
         payload = LeeRcriInput(

--- a/src/frontend/scales/soba.py
+++ b/src/frontend/scales/soba.py
@@ -88,7 +88,7 @@ def show_soba_scale():
                 value=bool(getattr(stored, "vte_history", False)),
             )
 
-        submitted = st.form_submit_button("💾 Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("💾 Сохранить", width='stretch')
 
     if submitted:
         # 1) обновим карточку пациента при изменениях

--- a/src/frontend/scales/stopbang.py
+++ b/src/frontend/scales/stopbang.py
@@ -77,7 +77,7 @@ def show_stopbang_scale():
             neck_circ_cm = st.number_input("Окружность шеи (см)", min_value=10.0, max_value=80.0, value=neck_circ_cm,
                                            step=0.5)
 
-        submitted = st.form_submit_button("💾 Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("💾 Сохранить", width='stretch')
 
     if submitted:
         data = StopBangInput(

--- a/src/frontend/t0.py
+++ b/src/frontend/t0.py
@@ -96,7 +96,7 @@ def show_t0_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t0_upsert_result(person.id, SliceT0Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t1.py
+++ b/src/frontend/t1.py
@@ -100,7 +100,7 @@ def show_t1_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t1_upsert_result(person.id, SliceT1Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t10.py
+++ b/src/frontend/t10.py
@@ -121,7 +121,7 @@ def show_t10_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t10_upsert_result(person.id, SliceT10Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t11.py
+++ b/src/frontend/t11.py
@@ -121,7 +121,7 @@ def show_t11_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t11_upsert_result(person.id, SliceT11Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t12.py
+++ b/src/frontend/t12.py
@@ -121,7 +121,7 @@ def show_t12_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t12_upsert_result(person.id, SliceT12Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t2.py
+++ b/src/frontend/t2.py
@@ -92,7 +92,7 @@ def show_t2_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t2_upsert_result(person.id, SliceT2Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t3.py
+++ b/src/frontend/t3.py
@@ -112,7 +112,7 @@ def show_t3_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t3_upsert_result(person.id, SliceT3Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t4.py
+++ b/src/frontend/t4.py
@@ -109,7 +109,7 @@ def show_t4_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t4_upsert_result(person.id, SliceT4Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t5.py
+++ b/src/frontend/t5.py
@@ -109,7 +109,7 @@ def show_t5_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t5_upsert_result(person.id, SliceT5Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t6.py
+++ b/src/frontend/t6.py
@@ -110,7 +110,7 @@ def show_t6_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t6_upsert_result(person.id, SliceT6Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t7.py
+++ b/src/frontend/t7.py
@@ -110,7 +110,7 @@ def show_t7_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t7_upsert_result(person.id, SliceT7Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t8.py
+++ b/src/frontend/t8.py
@@ -116,7 +116,7 @@ def show_t8_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t8_upsert_result(person.id, SliceT8Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)

--- a/src/frontend/t9.py
+++ b/src/frontend/t9.py
@@ -148,7 +148,7 @@ def show_t9_slice():
                             except ValueError:
                                 val = None
                     values[name] = val
-        submitted = st.form_submit_button("Сохранить", use_container_width=True)
+        submitted = st.form_submit_button("Сохранить", width='stretch')
     if submitted:
         t9_upsert_result(person.id, SliceT9Input(**values))
         st.session_state["current_patient_info"] = get_person(person.id)


### PR DESCRIPTION
## Summary
- replace deprecated `use_container_width` with `width='stretch'`
- limit patient data export to Excel and drop CSV/JSON outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd8ff75ea883279b0d48f04441792c