### PR TITLE
Add back navigation and advanced patient search

### DIFF
--- a/src/database/functions.py
+++ b/src/database/functions.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from database.db import SessionLocal
 from database.schemas.ariscat import AriscatInput, AriscatRead
 from database.schemas.caprini import CapriniRead, CapriniInput
@@ -173,10 +175,29 @@ def update_person_fields(person_id: int, **fields):
         return svc.update_person(person_id, PersonUpdate(**fields))
 
 
-def search_persons(query: str, limit: int = 50, offset: int = 0):
+def search_persons(
+    *,
+    last_name: str | None = None,
+    first_name: str | None = None,
+    patronymic: str | None = None,
+    age: int | None = None,
+    card_number: str | None = None,
+    inclusion_date: date | None = None,
+    limit: int = 50,
+    offset: int = 0,
+):
     with SessionLocal() as session:
         svc = PersonsService(session)
-        return svc.search_persons(query, limit=limit, offset=offset)
+        return svc.search_persons(
+            last_name=last_name,
+            first_name=first_name,
+            patronymic=patronymic,
+            age=age,
+            card_number=card_number,
+            inclusion_date=inclusion_date,
+            limit=limit,
+            offset=offset,
+        )
 
 
 def rcri_get_result(person_id: int) -> LeeRcriRead | None:

--- a/src/database/services/persons.py
+++ b/src/database/services/persons.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import List
 
 from sqlalchemy.orm import Session
@@ -59,6 +60,25 @@ class PersonsService:
             raise NotFoundError(f"Person #{person_id} not found")
         return True
 
-    def search_persons(self, query: str, limit: int = 50, offset: int = 0) -> List[PersonRead]:
-        persons = self.repo.search_by_fio(query, limit=limit, offset=offset)
+    def search_persons(
+        self,
+        last_name: str | None = None,
+        first_name: str | None = None,
+        patronymic: str | None = None,
+        age: int | None = None,
+        card_number: str | None = None,
+        inclusion_date: date | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[PersonRead]:
+        persons = self.repo.search(
+            last_name=last_name,
+            first_name=first_name,
+            patronymic=patronymic,
+            age=age,
+            card_number=card_number,
+            inclusion_date=inclusion_date,
+            limit=limit,
+            offset=offset,
+        )
         return [PersonRead.model_validate(p) for p in persons]

--- a/src/frontend/component/loader.py
+++ b/src/frontend/component/loader.py
@@ -4,6 +4,8 @@ import pandas as pd
 import streamlit as st
 
 import database.functions as db_funcs
+from frontend.general import create_big_button
+from frontend.utils import change_menu_item
 
 
 # ===== helpers =====
@@ -209,4 +211,12 @@ def export_patient_data():
 
     st.caption(
         "Если какая-то шкала или срез не заполнены, в выгрузке будут пустые значения для их полей."
+    )
+
+    st.markdown("---")
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "diagnosis_patient"},
+        key="back_btn",
     )

--- a/src/frontend/patient.py
+++ b/src/frontend/patient.py
@@ -107,27 +107,50 @@ def add_patient():
 def find_patient():
     st.title("🔍 Поиск пациента")
 
-    # Форма ввода запроса
-    with st.form("find_patient_form", clear_on_submit=False):
-        q = st.text_input("Фамилия (или часть ФИО)", key="patients_find_q",
-                          placeholder="Например: Иванов")
+    results = None
+    with st.form("find_patient_form"):
+        c1, c2, c3 = st.columns(3)
+        with c1:
+            last_name = st.text_input("Фамилия")
+        with c2:
+            first_name = st.text_input("Имя")
+        with c3:
+            patronymic = st.text_input("Отчество")
+
+        c4, c5, c6 = st.columns(3)
+        with c4:
+            age = st.text_input("Возраст")
+        with c5:
+            card_number = st.text_input("Номер истории")
+        with c6:
+            inclusion_date = st.date_input("Дата добавления", value=None)
+
         submitted = st.form_submit_button("Искать", use_container_width=True)
 
-    # При сабмите — фиксируем запрос и делаем rerun
     if submitted:
-        q_fixed = (q or "").strip()
-        if not q_fixed:
-            st.warning("Введите хотя бы 1 символ для поиска.")
+        filters = {}
+        if last_name.strip():
+            filters["last_name"] = last_name.strip()
+        if first_name.strip():
+            filters["first_name"] = first_name.strip()
+        if patronymic.strip():
+            filters["patronymic"] = patronymic.strip()
+        if card_number.strip():
+            filters["card_number"] = card_number.strip()
+        if age.strip():
+            try:
+                filters["age"] = int(age.strip())
+            except ValueError:
+                st.warning("Возраст должен быть числом.")
+        if inclusion_date:
+            filters["inclusion_date"] = inclusion_date
+
+        if not filters:
+            st.warning("Заполните хотя бы одно поле для поиска.")
         else:
-            st.session_state["patients_find_q_committed"] = q_fixed
-            st.rerun()
+            results = search_persons(limit=100, **filters)
 
-    # Берём «зафиксированный» запрос
-    q_committed = st.session_state.get("patients_find_q_committed", "").strip()
-
-    # Рендерим результаты независимо от submitted
-    if q_committed:
-        results = search_persons(q_committed, limit=100)
+    if results is not None:
         if not results:
             st.info("Ничего не найдено.")
         else:
@@ -156,8 +179,12 @@ def find_patient():
                         st.rerun()
 
     st.markdown("---")
-    create_big_button("⬅️ Назад", on_click=change_menu_item,
-                      kwargs={"item": "patients"}, key="back_from_search")
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "patients"},
+        key="back_from_search",
+    )
 
 
 def export_patients():


### PR DESCRIPTION
## Summary
- Add missing back button on patient data export page
- Support patient lookup by name, age, card number and inclusion date

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd93e23504832797ca1f17a4094073