### PR TITLE
Add back buttons and patient search filters

### DIFF
--- a/src/database/functions.py
+++ b/src/database/functions.py
@@ -1,4 +1,5 @@
 from database.db import SessionLocal
+from datetime import date
 from database.schemas.ariscat import AriscatInput, AriscatRead
 from database.schemas.caprini import CapriniRead, CapriniInput
 from database.schemas.elganzouri import ElGanzouriRead, ElGanzouriInput
@@ -173,10 +174,29 @@ def update_person_fields(person_id: int, **fields):
         return svc.update_person(person_id, PersonUpdate(**fields))
 
 
-def search_persons(query: str, limit: int = 50, offset: int = 0):
+def search_persons(
+    *,
+    last_name: str | None = None,
+    first_name: str | None = None,
+    patronymic: str | None = None,
+    age: int | None = None,
+    card_number: str | None = None,
+    inclusion_date: date | None = None,
+    limit: int = 50,
+    offset: int = 0,
+):
     with SessionLocal() as session:
         svc = PersonsService(session)
-        return svc.search_persons(query, limit=limit, offset=offset)
+        return svc.search_persons(
+            last_name=last_name,
+            first_name=first_name,
+            patronymic=patronymic,
+            age=age,
+            card_number=card_number,
+            inclusion_date=inclusion_date,
+            limit=limit,
+            offset=offset,
+        )
 
 
 def rcri_get_result(person_id: int) -> LeeRcriRead | None:

--- a/src/database/services/persons.py
+++ b/src/database/services/persons.py
@@ -1,4 +1,5 @@
 from typing import List
+from datetime import date
 
 from sqlalchemy.orm import Session
 from database.models import Person
@@ -59,6 +60,26 @@ class PersonsService:
             raise NotFoundError(f"Person #{person_id} not found")
         return True
 
-    def search_persons(self, query: str, limit: int = 50, offset: int = 0) -> List[PersonRead]:
-        persons = self.repo.search_by_fio(query, limit=limit, offset=offset)
+    def search_persons(
+        self,
+        *,
+        last_name: str | None = None,
+        first_name: str | None = None,
+        patronymic: str | None = None,
+        age: int | None = None,
+        card_number: str | None = None,
+        inclusion_date: date | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[PersonRead]:
+        persons = self.repo.search(
+            last_name=last_name,
+            first_name=first_name,
+            patronymic=patronymic,
+            age=age,
+            card_number=card_number,
+            inclusion_date=inclusion_date,
+            limit=limit,
+            offset=offset,
+        )
         return [PersonRead.model_validate(p) for p in persons]

--- a/src/frontend/component/loader.py
+++ b/src/frontend/component/loader.py
@@ -3,6 +3,8 @@ import pandas as pd
 import streamlit as st
 
 import database.functions as db_funcs
+from frontend.general import create_big_button
+from frontend.utils import change_menu_item
 
 
 # ===== helpers =====
@@ -189,4 +191,10 @@ def export_patient_data():
 
     st.caption(
         "Если какая-то шкала или срез не заполнены, в выгрузке будут пустые значения для их полей."
+    )
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "diagnosis_patient"},
+        key="back_btn",
     )

--- a/src/frontend/operation.py
+++ b/src/frontend/operation.py
@@ -176,7 +176,7 @@ def show_postoperative():
     col5, col6 = st.columns([2, 1])
     with col5:
         st.markdown(
-            f"**Срез t11 - конец 1-х суток после операции**  \nСтатус: {'✅ Заполнено' if t11_filled else '❌ Не заполнено'}"
+            f"**Срез t11 - конец 2-х суток после операции**  \nСтатус: {'✅ Заполнено' if t11_filled else '❌ Не заполнено'}"
         )
     with col6:
         create_big_button(

--- a/src/frontend/patient.py
+++ b/src/frontend/patient.py
@@ -107,27 +107,44 @@ def add_patient():
 def find_patient():
     st.title("🔍 Поиск пациента")
 
-    # Форма ввода запроса
     with st.form("find_patient_form", clear_on_submit=False):
-        q = st.text_input("Фамилия (или часть ФИО)", key="patients_find_q",
-                          placeholder="Например: Иванов")
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            last_name = st.text_input("Фамилия", key="patients_find_last_name")
+        with col2:
+            first_name = st.text_input("Имя", key="patients_find_first_name")
+        with col3:
+            patronymic = st.text_input("Отчество", key="patients_find_patronymic")
+
+        col4, col5, col6 = st.columns(3)
+        with col4:
+            age_str = st.text_input("Возраст", key="patients_find_age")
+        with col5:
+            card_number = st.text_input("Номер истории", key="patients_find_card")
+        with col6:
+            inclusion_date = st.date_input("Дата добавления", value=None, key="patients_find_date")
+
         submitted = st.form_submit_button("Искать", width='stretch')
 
-    # При сабмите — фиксируем запрос и делаем rerun
     if submitted:
-        q_fixed = (q or "").strip()
-        if not q_fixed:
-            st.warning("Введите хотя бы 1 символ для поиска.")
-        else:
-            st.session_state["patients_find_q_committed"] = q_fixed
-            st.rerun()
+        filters = {
+            "last_name": (last_name or "").strip() or None,
+            "first_name": (first_name or "").strip() or None,
+            "patronymic": (patronymic or "").strip() or None,
+            "card_number": (card_number or "").strip() or None,
+            "inclusion_date": inclusion_date,
+        }
+        try:
+            filters["age"] = int(age_str) if age_str.strip() else None
+        except ValueError:
+            st.warning("Возраст должен быть числом")
+            filters["age"] = None
+        st.session_state["patients_find_filters"] = filters
+        st.rerun()
 
-    # Берём «зафиксированный» запрос
-    q_committed = st.session_state.get("patients_find_q_committed", "").strip()
-
-    # Рендерим результаты независимо от submitted
-    if q_committed:
-        results = search_persons(q_committed, limit=100)
+    filters = st.session_state.get("patients_find_filters")
+    if filters:
+        results = search_persons(limit=100, **filters)
         if not results:
             st.info("Ничего не найдено.")
         else:

--- a/src/frontend/t11.py
+++ b/src/frontend/t11.py
@@ -86,7 +86,7 @@ FIELD_DEFS = [
 def show_t11_slice():
     person = st.session_state["current_patient_info"]
     st.title(f"t11 показатели пациента {person.fio}")
-    st.caption("конец 1-х суток после операции")
+    st.caption("конец 2-х суток после операции")
 
     existing = t11_get_result(person.id)
     defaults = existing.model_dump() if existing else {}


### PR DESCRIPTION
## Summary
- add missing back button to patient data export page
- extend patient search by name, age, card number and date
- fix T11 stage caption to end of 2 days post-op

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bd9548dc7483279b42155b82e184c1