### PR TITLE
Ensure back buttons use full-width style

### DIFF
--- a/src/frontend/operation.py
+++ b/src/frontend/operation.py
@@ -5,7 +5,12 @@ from frontend.general import create_big_button
 
 
 def _back():
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "diagnosis_patient"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "diagnosis_patient"},
+        key="back_btn",
+    )
 
 def show_operation():
     person = st.session_state["current_patient_info"]

--- a/src/frontend/t0.py
+++ b/src/frontend/t0.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t0 import SliceT0Input
 from database.functions import t0_get_result, t0_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 FIELD_DEFS = [
     ("date", "Дата", "", "date"),
@@ -103,4 +104,9 @@ def show_t0_slice():
         st.success("Данные сохранены")
         change_menu_item(item="preoperative_exam")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "preoperative_exam"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "preoperative_exam"},
+        key="back_btn",
+    )

--- a/src/frontend/t1.py
+++ b/src/frontend/t1.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t1 import SliceT1Input
 from database.functions import t1_get_result, t1_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 FIELD_DEFS = [
     ("date", "Дата", "", "date"),
@@ -107,4 +108,9 @@ def show_t1_slice():
         st.success("Данные сохранены")
         change_menu_item(item="operation")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "operation"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "operation"},
+        key="back_btn",
+    )

--- a/src/frontend/t10.py
+++ b/src/frontend/t10.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t10 import SliceT10Input
 from database.functions import t10_get_result, t10_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 
 FIELD_DEFS = [
@@ -128,4 +129,9 @@ def show_t10_slice():
         st.success("Данные сохранены")
         change_menu_item(item="postoperative_period")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "postoperative_period"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "postoperative_period"},
+        key="back_btn",
+    )

--- a/src/frontend/t11.py
+++ b/src/frontend/t11.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t11 import SliceT11Input
 from database.functions import t11_get_result, t11_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 
 FIELD_DEFS = [
@@ -128,4 +129,9 @@ def show_t11_slice():
         st.success("Данные сохранены")
         change_menu_item(item="postoperative_period")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "postoperative_period"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "postoperative_period"},
+        key="back_btn",
+    )

--- a/src/frontend/t12.py
+++ b/src/frontend/t12.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t12 import SliceT12Input
 from database.functions import t12_get_result, t12_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 
 FIELD_DEFS = [
@@ -128,4 +129,9 @@ def show_t12_slice():
         st.success("Данные сохранены")
         change_menu_item(item="postoperative_period")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "postoperative_period"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "postoperative_period"},
+        key="back_btn",
+    )

--- a/src/frontend/t2.py
+++ b/src/frontend/t2.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t2 import SliceT2Input
 from database.functions import t2_get_result, t2_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 FIELD_DEFS = [
     ("date", "Дата", "", "date"),
@@ -99,4 +100,9 @@ def show_t2_slice():
         st.success("Данные сохранены")
         change_menu_item(item="operation")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "operation"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "operation"},
+        key="back_btn",
+    )

--- a/src/frontend/t3.py
+++ b/src/frontend/t3.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t3 import SliceT3Input
 from database.functions import t3_get_result, t3_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 FIELD_DEFS = [
     ("date", "Дата", "", "date"),
@@ -119,4 +120,9 @@ def show_t3_slice():
         st.success("Данные сохранены")
         change_menu_item(item="operation")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "operation"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "operation"},
+        key="back_btn",
+    )

--- a/src/frontend/t4.py
+++ b/src/frontend/t4.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t4 import SliceT4Input
 from database.functions import t4_get_result, t4_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 
 FIELD_DEFS = [
@@ -116,5 +117,10 @@ def show_t4_slice():
         st.success("Данные сохранены")
         change_menu_item(item="operation")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "operation"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "operation"},
+        key="back_btn",
+    )
 

--- a/src/frontend/t5.py
+++ b/src/frontend/t5.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t5 import SliceT5Input
 from database.functions import t5_get_result, t5_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 
 FIELD_DEFS = [
@@ -116,4 +117,9 @@ def show_t5_slice():
         st.success("Данные сохранены")
         change_menu_item(item="operation")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "operation"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "operation"},
+        key="back_btn",
+    )

--- a/src/frontend/t6.py
+++ b/src/frontend/t6.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t6 import SliceT6Input
 from database.functions import t6_get_result, t6_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 
 FIELD_DEFS = [
@@ -117,4 +118,9 @@ def show_t6_slice():
         st.success("Данные сохранены")
         change_menu_item(item="operation")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "operation"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "operation"},
+        key="back_btn",
+    )

--- a/src/frontend/t7.py
+++ b/src/frontend/t7.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t7 import SliceT7Input
 from database.functions import t7_get_result, t7_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 
 FIELD_DEFS = [
@@ -117,5 +118,10 @@ def show_t7_slice():
         st.success("Данные сохранены")
         change_menu_item(item="operation")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "operation"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "operation"},
+        key="back_btn",
+    )
 

--- a/src/frontend/t8.py
+++ b/src/frontend/t8.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t8 import SliceT8Input
 from database.functions import t8_get_result, t8_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 
 FIELD_DEFS = [
@@ -123,4 +124,9 @@ def show_t8_slice():
         st.success("Данные сохранены")
         change_menu_item(item="operation")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "operation"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "operation"},
+        key="back_btn",
+    )

--- a/src/frontend/t9.py
+++ b/src/frontend/t9.py
@@ -5,6 +5,7 @@ import streamlit as st
 from database.schemas.slice_t9 import SliceT9Input
 from database.functions import t9_get_result, t9_upsert_result, get_person
 from frontend.utils import change_menu_item
+from frontend.components import create_big_button
 
 
 FIELD_DEFS = [
@@ -155,5 +156,10 @@ def show_t9_slice():
         st.success("Данные сохранены")
         change_menu_item(item="postoperative_period")
         st.rerun()
-    st.button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "postoperative_period"})
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "postoperative_period"},
+        key="back_btn",
+    )
 


### PR DESCRIPTION
## Summary
- Use `create_big_button` for back navigation across all t0–t12 slice screens
- Update operation view to employ `create_big_button` helper for back button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bdda10c1a083278c9648755615ebcb