### PR TITLE
Add LAS VEGAS postoperative risk scale

### DIFF
--- a/src/database/functions.py
+++ b/src/database/functions.py
@@ -7,6 +7,7 @@ from database.schemas.lee import LeeRcriRead, LeeRcriInput, LeeRcriUpdate
 from database.schemas.persons import PersonCreate, PersonRead, PersonUpdate
 from database.schemas.soba import SobaRead, SobaCreate, SobaUpdate
 from database.schemas.stopbang import StopBangRead, StopBangInput
+from database.schemas.las_vegas import LasVegasRead, LasVegasInput
 from database.schemas.slice_t0 import SliceT0Input, SliceT0Read
 from database.schemas.slice_t1 import SliceT1Input, SliceT1Read
 from database.schemas.slice_t2 import SliceT2Input, SliceT2Read
@@ -17,6 +18,7 @@ from database.services.lee import LeeRcriService
 from database.services.persons import PersonsService
 from database.services.soba import SobaService
 from database.services.stopbang import StopBangService
+from database.services.las_vegas import LasVegasService
 from database.services.slice_t0 import SliceT0Service
 from database.services.slice_t1 import SliceT1Service
 from database.services.slice_t2 import SliceT2Service
@@ -165,6 +167,27 @@ def delete_soba(person_id: int) -> bool:
     with SessionLocal() as session:
         svc = SobaService(session)
         return svc.delete_for_person(person_id)
+
+
+def lv_get_result(person_id: int) -> LasVegasRead | None:
+    with SessionLocal() as session:
+        svc = LasVegasService(session)
+        try:
+            return svc.get_result(person_id)
+        except NotFoundError:
+            return None
+
+
+def lv_upsert_result(person_id: int, data: LasVegasInput) -> LasVegasRead:
+    with SessionLocal() as session:
+        svc = LasVegasService(session)
+        return svc.upsert_result(person_id, data)
+
+
+def lv_clear_result(person_id: int) -> bool:
+    with SessionLocal() as session:
+        svc = LasVegasService(session)
+        return svc.clear_result(person_id)
 
 
 def update_person_fields(person_id: int, **fields):

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -116,6 +116,7 @@ class PersonScales(Base):
     soba_filled = Column(Boolean, nullable=False, default=False)
     lee_rcri_filled = Column(Boolean, nullable=False, default=False)
     caprini_filled = Column(Boolean, nullable=False, default=False)
+    las_vegas_filled = Column(Boolean, nullable=False, default=False)
 
     # Технические поля
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -148,6 +149,10 @@ class PersonScales(Base):
         "CapriniResult", back_populates="scales",
         uselist=False, cascade="all, delete-orphan"
     )
+    las_vegas = relationship(
+        "LasVegasResult", back_populates="scales",
+        uselist=False, cascade="all, delete-orphan"
+    )
 
     def __repr__(self):
         return (
@@ -157,7 +162,8 @@ class PersonScales(Base):
             f"stopbang={self.stopbang_filled}, "
             f"soba={self.soba_filled}, "
             f"lee_rcri={self.lee_rcri_filled}, "
-            f"caprini={self.caprini_filled})>"
+            f"caprini={self.caprini_filled}, "
+            f"las_vegas={self.las_vegas_filled})>"
         )
 
 
@@ -1612,3 +1618,32 @@ class CapriniResult(Base):
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
     scales = relationship("PersonScales", back_populates="caprini")
+
+
+class LasVegasResult(Base):
+    __tablename__ = "las_vegas_results"
+    __table_args__ = (UniqueConstraint("scales_id", name="uq_las_vegas_scales"),)
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    scales_id = Column(Integer, ForeignKey("person_scales.id", ondelete="CASCADE"), nullable=False, index=True)
+
+    age_years = Column(Integer, nullable=True)
+    asa_ps = Column(Integer, nullable=True)
+    preop_spo2 = Column(Integer, nullable=True)
+    cancer = Column(Boolean, nullable=True)
+    osa = Column(Boolean, nullable=True)
+    elective = Column(Boolean, nullable=True)
+    duration_minutes = Column(Integer, nullable=True)
+    supraglottic_device = Column(Boolean, nullable=True)
+    anesthesia_type = Column(String(32), nullable=True)
+    intraop_desaturation = Column(Boolean, nullable=True)
+    vasoactive_drugs = Column(Boolean, nullable=True)
+    peep_cm_h2o = Column(Float, nullable=True)
+
+    total_score = Column(Integer, nullable=False, default=0)
+    risk_level = Column(Integer, nullable=False, default=0)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    scales = relationship("PersonScales", back_populates="las_vegas")

--- a/src/database/repositories/las_vegas.py
+++ b/src/database/repositories/las_vegas.py
@@ -1,0 +1,22 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import select, delete
+
+from database.models import LasVegasResult
+
+
+class LasVegasRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def get_by_scales_id(self, scales_id: int) -> LasVegasResult | None:
+        stmt = select(LasVegasResult).where(LasVegasResult.scales_id == scales_id)
+        return self.session.execute(stmt).scalar_one_or_none()
+
+    def add(self, obj: LasVegasResult) -> LasVegasResult:
+        self.session.add(obj)
+        return obj
+
+    def delete_by_scales_id(self, scales_id: int) -> int:
+        stmt = delete(LasVegasResult).where(LasVegasResult.scales_id == scales_id)
+        res = self.session.execute(stmt)
+        return res.rowcount or 0

--- a/src/database/schemas/las_vegas.py
+++ b/src/database/schemas/las_vegas.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class LasVegasInput(BaseModel):
+    age_years: int
+    asa_ps: int
+    preop_spo2: int
+    cancer: bool
+    osa: bool
+    elective: bool
+    duration_minutes: int
+    supraglottic_device: bool
+    anesthesia_type: str
+    intraop_desaturation: bool
+    vasoactive_drugs: bool
+    peep_cm_h2o: float
+
+
+class LasVegasRead(LasVegasInput):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    scales_id: int
+    total_score: int
+    risk_level: int

--- a/src/database/schemas/person_scales.py
+++ b/src/database/schemas/person_scales.py
@@ -9,6 +9,7 @@ class PersonScalesRead(BaseModel):
     soba_filled: bool = False
     lee_rcri_filled: bool = False
     caprini_filled: bool = False
+    las_vegas_filled: bool = False
 
     class Config:
         from_attributes = True
@@ -21,3 +22,4 @@ class PersonScalesUpdate(BaseModel):
     soba_stopbang_filled: Optional[bool] = None
     lee_rcri_filled: Optional[bool] = None
     caprini_filled: Optional[bool] = None
+    las_vegas_filled: Optional[bool] = None

--- a/src/database/services/las_vegas.py
+++ b/src/database/services/las_vegas.py
@@ -1,0 +1,107 @@
+from sqlalchemy.orm import Session
+
+from database.models import PersonScales, LasVegasResult
+from database.repositories.person_scales import PersonScalesRepository
+from database.repositories.las_vegas import LasVegasRepository
+from database.schemas.las_vegas import LasVegasInput, LasVegasRead
+from database.services.utils import NotFoundError
+
+
+def _risk_level(score: int) -> int:
+    if score >= 6:
+        return 2
+    if score >= 3:
+        return 1
+    return 0
+
+
+class LasVegasService:
+    def __init__(self, session: Session):
+        self.session = session
+        self.ps_repo = PersonScalesRepository(session)
+        self.repo = LasVegasRepository(session)
+
+    def _get_or_create_ps(self, person_id: int) -> PersonScales:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if ps is None:
+            ps = PersonScales(person_id=person_id)
+            self.ps_repo.add(ps)
+            self.session.flush()
+        return ps
+
+    def upsert_result(self, person_id: int, data: LasVegasInput) -> LasVegasRead:
+        ps = self._get_or_create_ps(person_id)
+        res = self.repo.get_by_scales_id(ps.id)
+        if res is None:
+            res = LasVegasResult(scales_id=ps.id)
+            self.repo.add(res)
+
+        # assign fields
+        res.age_years = int(data.age_years)
+        res.asa_ps = int(data.asa_ps)
+        res.preop_spo2 = int(data.preop_spo2)
+        res.cancer = bool(data.cancer)
+        res.osa = bool(data.osa)
+        res.elective = bool(data.elective)
+        res.duration_minutes = int(data.duration_minutes)
+        res.supraglottic_device = bool(data.supraglottic_device)
+        res.anesthesia_type = str(data.anesthesia_type)
+        res.intraop_desaturation = bool(data.intraop_desaturation)
+        res.vasoactive_drugs = bool(data.vasoactive_drugs)
+        res.peep_cm_h2o = float(data.peep_cm_h2o)
+
+        score = 0
+        if data.age_years >= 67:
+            score += 2
+        elif data.age_years >= 47:
+            score += 1
+        if data.asa_ps >= 3:
+            score += 1
+        if data.preop_spo2 < 96:
+            score += 1
+        if data.cancer:
+            score += 1
+        if data.osa:
+            score += 1
+        if not data.elective:
+            score += 1
+        if data.duration_minutes >= 135:
+            score += 1
+        if data.supraglottic_device:
+            score += 1
+        if str(data.anesthesia_type).lower() != "balanced":
+            score += 1
+        if data.intraop_desaturation:
+            score += 1
+        if data.vasoactive_drugs:
+            score += 1
+        if data.peep_cm_h2o < 5:
+            score += 1
+
+        res.total_score = score
+        res.risk_level = _risk_level(score)
+
+        self.ps_repo.update_fields(ps, las_vegas_filled=True)
+        self.session.commit()
+        self.session.refresh(res)
+        self.session.refresh(ps)
+        return LasVegasRead.model_validate(res)
+
+    def clear_result(self, person_id: int) -> bool:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if not ps:
+            raise NotFoundError("PersonScales not found")
+        affected = self.repo.delete_by_scales_id(ps.id)
+        if affected:
+            self.ps_repo.update_fields(ps, las_vegas_filled=False)
+        self.session.commit()
+        return bool(affected)
+
+    def get_result(self, person_id: int) -> LasVegasRead:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if not ps:
+            raise NotFoundError("PersonScales not found")
+        res = self.repo.get_by_scales_id(ps.id)
+        if not res:
+            raise NotFoundError("LasVegasResult not found")
+        return LasVegasRead.model_validate(res)

--- a/src/database/services/person_scales.py
+++ b/src/database/services/person_scales.py
@@ -48,11 +48,11 @@ class PersonScalesService:
     def set_flag(self, person_id: int, scale_name: str, value: bool) -> PersonScalesRead:
         """
         scale_name: одно из
-        ['el_ganzouri_filled','ariscat_filled','soba_stopbang_filled','lee_rcri_filled','caprini_filled']
+        ['el_ganzouri_filled','ariscat_filled','soba_stopbang_filled','lee_rcri_filled','caprini_filled','las_vegas_filled']
         """
         if scale_name not in {
             "el_ganzouri_filled", "ariscat_filled", "soba_stopbang_filled",
-            "lee_rcri_filled", "caprini_filled"
+            "lee_rcri_filled", "caprini_filled", "las_vegas_filled"
         }:
             raise ValueError(f"Unknown scale flag: {scale_name}")
 

--- a/src/frontend/operation.py
+++ b/src/frontend/operation.py
@@ -144,7 +144,7 @@ def show_operation():
 def show_postoperative():
     person = st.session_state["current_patient_info"]
     st.title(f"🏥 Послеоперационный период пациента {person.fio}")
-
+    scales_status = getattr(person, "scales", None)
     slices_status = getattr(person, "slices", None)
     t9_filled = bool(getattr(slices_status, "t9_filled", False)) if slices_status else False
     t10_filled = bool(getattr(slices_status, "t10_filled", False)) if slices_status else False
@@ -204,6 +204,21 @@ def show_postoperative():
             kwargs={"item": "show_t12_slice"},
             icon="📝",
             key="t12_btn",
+        )
+
+    las_filled = bool(getattr(scales_status, 'las_vegas_filled', False)) if scales_status else False
+    col9, col10 = st.columns([2, 1])
+    with col9:
+        st.markdown(
+            f"**Шкала LAS VEGAS — оценка послеоперационного риска**  \nСтатус: {'✅ Заполнено' if las_filled else '❌ Не заполнено'}"
+        )
+    with col10:
+        create_big_button(
+            'Перейти',
+            on_click=change_menu_item,
+            kwargs={'item': 'show_las_vegas_scale'},
+            icon='🧮',
+            key='las_vegas_btn',
         )
 
 

--- a/src/frontend/scales/las_vegas.py
+++ b/src/frontend/scales/las_vegas.py
@@ -1,0 +1,91 @@
+import streamlit as st
+
+from database.functions import lv_get_result, lv_upsert_result, get_person
+from database.schemas.las_vegas import LasVegasInput
+from frontend.components import create_big_button
+from frontend.utils import change_menu_item
+
+
+def _risk_label(level: int | None) -> str:
+    if level is None:
+        return "—"
+    return ["Низкий", "Промежуточный", "Высокий"][max(0, min(2, int(level)))]
+
+
+def show_las_vegas_scale():
+    person = st.session_state.get("current_patient_info")
+    if not person:
+        st.error("Пациент не выбран.")
+        return
+
+    st.subheader("Шкала LAS VEGAS — оценка послеоперационного риска")
+
+    stored = lv_get_result(person.id)
+
+    age = int(getattr(stored, "age_years", getattr(person, "age", 50) or 50))
+    asa_ps = int(getattr(stored, "asa_ps", 3))
+    preop_spo2 = int(getattr(stored, "preop_spo2", 96))
+    cancer = bool(getattr(stored, "cancer", False))
+    osa = bool(getattr(stored, "osa", False))
+    elective = bool(getattr(stored, "elective", True))
+    duration = int(getattr(stored, "duration_minutes", 135))
+    supraglottic = bool(getattr(stored, "supraglottic_device", False))
+    anesthesia_type = getattr(stored, "anesthesia_type", "balanced")
+    desaturation = bool(getattr(stored, "intraop_desaturation", False))
+    vasoactives = bool(getattr(stored, "vasoactive_drugs", False))
+    peep = float(getattr(stored, "peep_cm_h2o", 5.0))
+
+    if stored:
+        st.info(
+            f"Текущие данные: баллы **{stored.total_score}** · риск **{_risk_label(stored.risk_level)}**"
+        )
+
+    with st.form("las_vegas_form"):
+        age = st.number_input("Возраст (лет)", min_value=0, max_value=130, value=age, step=1)
+        asa_ps = st.number_input("ASA PS", min_value=1, max_value=5, value=asa_ps, step=1)
+        preop_spo2 = st.number_input("Предоперационная SpO₂ (%)", min_value=0, max_value=100, value=preop_spo2, step=1)
+        cancer = st.checkbox("Онкологическое заболевание", value=cancer)
+        osa = st.checkbox("Синдром обструктивного апноэ сна", value=osa)
+        elective = st.checkbox("Плановая операция", value=elective)
+        duration = st.number_input("Длительность операции (мин)", min_value=0, max_value=1000, value=duration, step=5)
+        supraglottic = st.checkbox("Использовались надгортанные устройства", value=supraglottic)
+        anesthesia_type = st.selectbox(
+            "Тип анестезии",
+            ["balanced", "tiva", "regional", "other"],
+            index=["balanced", "tiva", "regional", "other"].index(anesthesia_type)
+            if anesthesia_type in ["balanced", "tiva", "regional", "other"]
+            else 0,
+        )
+        desaturation = st.checkbox("Десатурация во время операции", value=desaturation)
+        vasoactives = st.checkbox("Потребность в вазоактивных препаратах", value=vasoactives)
+        peep = st.number_input("ПДКВ (смH₂O)", min_value=0.0, max_value=20.0, value=peep, step=0.5)
+
+        submitted = st.form_submit_button("💾 Сохранить", width='stretch')
+
+    if submitted:
+        data = LasVegasInput(
+            age_years=age,
+            asa_ps=asa_ps,
+            preop_spo2=preop_spo2,
+            cancer=cancer,
+            osa=osa,
+            elective=elective,
+            duration_minutes=duration,
+            supraglottic_device=supraglottic,
+            anesthesia_type=anesthesia_type,
+            intraop_desaturation=desaturation,
+            vasoactive_drugs=vasoactives,
+            peep_cm_h2o=peep,
+        )
+        saved = lv_upsert_result(person.id, data)
+        st.success(
+            f"Сохранено. Баллы: **{saved.total_score}** · риск: **{_risk_label(saved.risk_level)}**"
+        )
+        st.session_state["current_patient_info"] = get_person(person.id)
+
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "postoperative_period"},
+        key="back_btn",
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ from frontend.scales.elganzouri import show_el_ganzouri_form
 from frontend.scales.lee import show_lee_scale
 from frontend.scales.soba import show_soba_scale
 from frontend.scales.stopbang import show_stopbang_scale
+from frontend.scales.las_vegas import show_las_vegas_scale
 from frontend.component.loader import export_patient_data
 from frontend.operation import show_operation, show_postoperative, show_operation_point
 from frontend.t0 import show_t0_slice
@@ -53,6 +54,7 @@ menu_items = {
     "show_soba_scale": show_soba_scale,
     "show_lee_scale": show_lee_scale,
     "show_caprini_scale": show_caprini_scale,
+    "show_las_vegas_scale": show_las_vegas_scale,
     "show_t0_slice": show_t0_slice,
     "show_t1_slice": show_t1_slice,
     "show_t2_slice": show_t2_slice,


### PR DESCRIPTION
## Summary
- add LAS VEGAS result model and persistence layer
- compute LAS VEGAS risk score and expose service functions
- provide Streamlit UI and integrate scale into postoperative workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c5c83ea51083279e0732cbc9a94e18