### PR TITLE
Add Aldrete scale calculator

### DIFF
--- a/src/database/functions.py
+++ b/src/database/functions.py
@@ -8,6 +8,7 @@ from database.schemas.persons import PersonCreate, PersonRead, PersonUpdate
 from database.schemas.soba import SobaRead, SobaCreate, SobaUpdate
 from database.schemas.stopbang import StopBangRead, StopBangInput
 from database.schemas.las_vegas import LasVegasRead, LasVegasInput
+from database.schemas.aldrete import AldreteRead, AldreteInput
 from database.schemas.slice_t0 import SliceT0Input, SliceT0Read
 from database.schemas.slice_t1 import SliceT1Input, SliceT1Read
 from database.schemas.slice_t2 import SliceT2Input, SliceT2Read
@@ -19,6 +20,7 @@ from database.services.persons import PersonsService
 from database.services.soba import SobaService
 from database.services.stopbang import StopBangService
 from database.services.las_vegas import LasVegasService
+from database.services.aldrete import AldreteService
 from database.services.slice_t0 import SliceT0Service
 from database.services.slice_t1 import SliceT1Service
 from database.services.slice_t2 import SliceT2Service
@@ -187,6 +189,27 @@ def lv_upsert_result(person_id: int, data: LasVegasInput) -> LasVegasRead:
 def lv_clear_result(person_id: int) -> bool:
     with SessionLocal() as session:
         svc = LasVegasService(session)
+        return svc.clear_result(person_id)
+
+
+def ald_get_result(person_id: int) -> AldreteRead | None:
+    with SessionLocal() as session:
+        svc = AldreteService(session)
+        try:
+            return svc.get_result(person_id)
+        except NotFoundError:
+            return None
+
+
+def ald_upsert_result(person_id: int, data: AldreteInput) -> AldreteRead:
+    with SessionLocal() as session:
+        svc = AldreteService(session)
+        return svc.upsert_result(person_id, data)
+
+
+def ald_clear_result(person_id: int) -> bool:
+    with SessionLocal() as session:
+        svc = AldreteService(session)
         return svc.clear_result(person_id)
 
 

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -117,6 +117,7 @@ class PersonScales(Base):
     lee_rcri_filled = Column(Boolean, nullable=False, default=False)
     caprini_filled = Column(Boolean, nullable=False, default=False)
     las_vegas_filled = Column(Boolean, nullable=False, default=False)
+    aldrete_filled = Column(Boolean, nullable=False, default=False)
 
     # Технические поля
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -153,6 +154,10 @@ class PersonScales(Base):
         "LasVegasResult", back_populates="scales",
         uselist=False, cascade="all, delete-orphan"
     )
+    aldrete = relationship(
+        "AldreteResult", back_populates="scales",
+        uselist=False, cascade="all, delete-orphan"
+    )
 
     def __repr__(self):
         return (
@@ -163,7 +168,8 @@ class PersonScales(Base):
             f"soba={self.soba_filled}, "
             f"lee_rcri={self.lee_rcri_filled}, "
             f"caprini={self.caprini_filled}, "
-            f"las_vegas={self.las_vegas_filled})>"
+            f"las_vegas={self.las_vegas_filled}, "
+            f"aldrete={self.aldrete_filled})>"
         )
 
 
@@ -1647,3 +1653,24 @@ class LasVegasResult(Base):
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
     scales = relationship("PersonScales", back_populates="las_vegas")
+
+
+class AldreteResult(Base):
+    __tablename__ = "aldrete_results"
+    __table_args__ = (UniqueConstraint("scales_id", name="uq_aldrete_scales"),)
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    scales_id = Column(Integer, ForeignKey("person_scales.id", ondelete="CASCADE"), nullable=False, index=True)
+
+    activity_score = Column(Integer, nullable=False, default=0)
+    respiration_score = Column(Integer, nullable=False, default=0)
+    pressure_score = Column(Integer, nullable=False, default=0)
+    consciousness_score = Column(Integer, nullable=False, default=0)
+    spo2_score = Column(Integer, nullable=False, default=0)
+
+    total_score = Column(Integer, nullable=False, default=0)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    scales = relationship("PersonScales", back_populates="aldrete")

--- a/src/database/repositories/aldrete.py
+++ b/src/database/repositories/aldrete.py
@@ -1,0 +1,22 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import select, delete
+
+from database.models import AldreteResult
+
+
+class AldreteRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def get_by_scales_id(self, scales_id: int) -> AldreteResult | None:
+        stmt = select(AldreteResult).where(AldreteResult.scales_id == scales_id)
+        return self.session.execute(stmt).scalar_one_or_none()
+
+    def add(self, obj: AldreteResult) -> AldreteResult:
+        self.session.add(obj)
+        return obj
+
+    def delete_by_scales_id(self, scales_id: int) -> int:
+        stmt = delete(AldreteResult).where(AldreteResult.scales_id == scales_id)
+        res = self.session.execute(stmt)
+        return res.rowcount or 0

--- a/src/database/schemas/aldrete.py
+++ b/src/database/schemas/aldrete.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class AldreteInput(BaseModel):
+    activity_score: int
+    respiration_score: int
+    pressure_score: int
+    consciousness_score: int
+    spo2_score: int
+
+
+class AldreteRead(AldreteInput):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    scales_id: int
+    total_score: int

--- a/src/database/schemas/person_scales.py
+++ b/src/database/schemas/person_scales.py
@@ -10,6 +10,7 @@ class PersonScalesRead(BaseModel):
     lee_rcri_filled: bool = False
     caprini_filled: bool = False
     las_vegas_filled: bool = False
+    aldrete_filled: bool = False
 
     class Config:
         from_attributes = True
@@ -23,3 +24,4 @@ class PersonScalesUpdate(BaseModel):
     lee_rcri_filled: Optional[bool] = None
     caprini_filled: Optional[bool] = None
     las_vegas_filled: Optional[bool] = None
+    aldrete_filled: Optional[bool] = None

--- a/src/database/services/aldrete.py
+++ b/src/database/services/aldrete.py
@@ -1,0 +1,67 @@
+from sqlalchemy.orm import Session
+
+from database.models import PersonScales, AldreteResult
+from database.repositories.person_scales import PersonScalesRepository
+from database.repositories.aldrete import AldreteRepository
+from database.schemas.aldrete import AldreteInput, AldreteRead
+from database.services.utils import NotFoundError
+
+
+class AldreteService:
+    def __init__(self, session: Session):
+        self.session = session
+        self.ps_repo = PersonScalesRepository(session)
+        self.repo = AldreteRepository(session)
+
+    def _get_or_create_ps(self, person_id: int) -> PersonScales:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if ps is None:
+            ps = PersonScales(person_id=person_id)
+            self.ps_repo.add(ps)
+            self.session.flush()
+        return ps
+
+    def upsert_result(self, person_id: int, data: AldreteInput) -> AldreteRead:
+        ps = self._get_or_create_ps(person_id)
+        res = self.repo.get_by_scales_id(ps.id)
+        if res is None:
+            res = AldreteResult(scales_id=ps.id)
+            self.repo.add(res)
+
+        res.activity_score = int(data.activity_score)
+        res.respiration_score = int(data.respiration_score)
+        res.pressure_score = int(data.pressure_score)
+        res.consciousness_score = int(data.consciousness_score)
+        res.spo2_score = int(data.spo2_score)
+        res.total_score = (
+            res.activity_score +
+            res.respiration_score +
+            res.pressure_score +
+            res.consciousness_score +
+            res.spo2_score
+        )
+
+        self.ps_repo.update_fields(ps, aldrete_filled=True)
+        self.session.commit()
+        self.session.refresh(res)
+        self.session.refresh(ps)
+        return AldreteRead.model_validate(res)
+
+    def clear_result(self, person_id: int) -> bool:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if not ps:
+            raise NotFoundError("PersonScales not found")
+        affected = self.repo.delete_by_scales_id(ps.id)
+        if affected:
+            self.ps_repo.update_fields(ps, aldrete_filled=False)
+        self.session.commit()
+        return bool(affected)
+
+    def get_result(self, person_id: int) -> AldreteRead:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if not ps:
+            raise NotFoundError("PersonScales not found")
+        res = self.repo.get_by_scales_id(ps.id)
+        if not res:
+            raise NotFoundError("AldreteResult not found")
+        return AldreteRead.model_validate(res)

--- a/src/database/services/person_scales.py
+++ b/src/database/services/person_scales.py
@@ -48,11 +48,12 @@ class PersonScalesService:
     def set_flag(self, person_id: int, scale_name: str, value: bool) -> PersonScalesRead:
         """
         scale_name: одно из
-        ['el_ganzouri_filled','ariscat_filled','soba_stopbang_filled','lee_rcri_filled','caprini_filled','las_vegas_filled']
+        ['el_ganzouri_filled','ariscat_filled','soba_stopbang_filled','lee_rcri_filled','caprini_filled','las_vegas_filled','aldrete_filled']
         """
         if scale_name not in {
             "el_ganzouri_filled", "ariscat_filled", "soba_stopbang_filled",
-            "lee_rcri_filled", "caprini_filled", "las_vegas_filled"
+            "lee_rcri_filled", "caprini_filled", "las_vegas_filled",
+            "aldrete_filled"
         }:
             raise ValueError(f"Unknown scale flag: {scale_name}")
 

--- a/src/frontend/calculate.py
+++ b/src/frontend/calculate.py
@@ -6,5 +6,15 @@ from frontend.utils import change_menu_item
 
 def show_calculators_menu():
     st.title("🧮 Калькуляторы")
-    st.write("Здесь будет меню калькуляторов.")
-    create_big_button("Назад", on_click=change_menu_item, kwargs={"item": "main"}, icon="⬅️")
+    create_big_button(
+        "Шкала Aldrete",
+        on_click=change_menu_item,
+        kwargs={"item": "show_aldrete_scale"},
+        icon="🛌",
+    )
+    create_big_button(
+        "Назад",
+        on_click=change_menu_item,
+        kwargs={"item": "main"},
+        icon="⬅️",
+    )

--- a/src/frontend/patient.py
+++ b/src/frontend/patient.py
@@ -430,6 +430,7 @@ def preoperative_exam():
         ("Рекомендации SOBA — план ведения при ожирении", "show_soba_scale", "soba_filled", "soba"),
         ("Индекс Lee (RCRI) — оценка кардиального риска", "show_lee_scale", "lee_rcri_filled", "lee_rcri"),
         ("Шкала Caprini — оценка риска ВТЭО", "show_caprini_scale", "caprini_filled", "caprini"),
+        ("Шкала Aldrete — оценка выхода из анестезии", "show_aldrete_scale", "aldrete_filled", "aldrete"),
     ]
 
     for i, (label, item, status_field, rel_field) in enumerate(scales):

--- a/src/frontend/scales/aldrete.py
+++ b/src/frontend/scales/aldrete.py
@@ -1,0 +1,92 @@
+import streamlit as st
+
+from database.functions import ald_get_result, ald_upsert_result, get_person
+from database.schemas.aldrete import AldreteInput
+from frontend.components import create_big_button
+from frontend.utils import change_menu_item
+
+
+def show_aldrete_scale():
+    person = st.session_state.get("current_patient_info")
+    if not person:
+        st.error("Пациент не выбран.")
+        create_big_button(
+            "⬅️ Назад",
+            on_click=change_menu_item,
+            kwargs={"item": "calculators"},
+            key="back_btn",
+        )
+        return
+
+    st.subheader("Шкала Aldrete — оценка выхода из анестезии")
+
+    stored = ald_get_result(person.id)
+
+    activity_opts = {
+        "движение всеми конечностями по команде": 2,
+        "движение двумя конечностями": 1,
+        "не двигается": 0,
+    }
+    respiration_opts = {
+        "глубокое дыхание и кашель": 2,
+        "одышка/поверхностное дыхание": 1,
+        "апноэ": 0,
+    }
+    pressure_opts = {
+        "в пределах 20% до уровня перед анестезией": 2,
+        "20–50% от исходного": 1,
+        ">50% от исходного": 0,
+    }
+    consciousness_opts = {
+        "ясное": 2,
+        "пробуждается при обращении": 1,
+        "не отвечает": 0,
+    }
+    spo2_opts = {
+        ">92% на воздухе": 2,
+        ">90% с кислородом": 1,
+        "<90% с кислородом": 0,
+    }
+
+    act_vals = list(activity_opts.values())
+    res_vals = list(respiration_opts.values())
+    pr_vals = list(pressure_opts.values())
+    con_vals = list(consciousness_opts.values())
+    sp_vals = list(spo2_opts.values())
+
+    act_idx = act_vals.index(getattr(stored, "activity_score", 2)) if getattr(stored, "activity_score", 2) in act_vals else 0
+    res_idx = res_vals.index(getattr(stored, "respiration_score", 2)) if getattr(stored, "respiration_score", 2) in res_vals else 0
+    pr_idx = pr_vals.index(getattr(stored, "pressure_score", 2)) if getattr(stored, "pressure_score", 2) in pr_vals else 0
+    con_idx = con_vals.index(getattr(stored, "consciousness_score", 2)) if getattr(stored, "consciousness_score", 2) in con_vals else 0
+    sp_idx = sp_vals.index(getattr(stored, "spo2_score", 2)) if getattr(stored, "spo2_score", 2) in sp_vals else 0
+
+    if stored:
+        st.info(f"Текущие данные: баллы **{stored.total_score}**")
+
+    with st.form("aldrete_form"):
+        activity_label = st.radio("Активность", list(activity_opts.keys()), index=act_idx)
+        respiration_label = st.radio("Дыхание", list(respiration_opts.keys()), index=res_idx)
+        pressure_label = st.radio("Артериальное давление", list(pressure_opts.keys()), index=pr_idx)
+        consciousness_label = st.radio("Сознание", list(consciousness_opts.keys()), index=con_idx)
+        spo2_label = st.radio("SpO₂", list(spo2_opts.keys()), index=sp_idx)
+        submitted = st.form_submit_button("💾 Сохранить", width='stretch')
+
+    if submitted:
+        data = AldreteInput(
+            activity_score=activity_opts[activity_label],
+            respiration_score=respiration_opts[respiration_label],
+            pressure_score=pressure_opts[pressure_label],
+            consciousness_score=consciousness_opts[consciousness_label],
+            spo2_score=spo2_opts[spo2_label],
+        )
+        saved = ald_upsert_result(person.id, data)
+        st.success(f"Сохранено. Баллы: **{saved.total_score}**")
+        st.session_state["current_patient_info"] = get_person(person.id)
+
+    back_item = "preoperative_exam" if st.session_state.get("current_patient_info") else "calculators"
+    create_big_button(
+        "⬅️ Назад",
+        on_click=change_menu_item,
+        kwargs={"item": back_item},
+        key="back_btn",
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from frontend.scales.lee import show_lee_scale
 from frontend.scales.soba import show_soba_scale
 from frontend.scales.stopbang import show_stopbang_scale
 from frontend.scales.las_vegas import show_las_vegas_scale
+from frontend.scales.aldrete import show_aldrete_scale
 from frontend.component.loader import export_patient_data
 from frontend.operation import show_operation, show_postoperative, show_operation_point
 from frontend.t0 import show_t0_slice
@@ -55,6 +56,7 @@ menu_items = {
     "show_lee_scale": show_lee_scale,
     "show_caprini_scale": show_caprini_scale,
     "show_las_vegas_scale": show_las_vegas_scale,
+    "show_aldrete_scale": show_aldrete_scale,
     "show_t0_slice": show_t0_slice,
     "show_t1_slice": show_t1_slice,
     "show_t2_slice": show_t2_slice,


### PR DESCRIPTION
## Summary
- persist Aldrete scale results with models, repository, service, and schema
- expose Aldrete scale in preoperative exam workflow and Streamlit UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c5e135497c8327bedb70cc9123f777