### PR TITLE
Add QoR-15 preoperative scale

### DIFF
--- a/src/database/functions.py
+++ b/src/database/functions.py
@@ -8,6 +8,7 @@ from database.schemas.persons import PersonCreate, PersonRead, PersonUpdate
 from database.schemas.soba import SobaRead, SobaCreate, SobaUpdate
 from database.schemas.stopbang import StopBangRead, StopBangInput
 from database.schemas.las_vegas import LasVegasRead, LasVegasInput
+from database.schemas.qor15 import Qor15Read, Qor15Input
 from database.schemas.slice_t0 import SliceT0Input, SliceT0Read
 from database.schemas.slice_t1 import SliceT1Input, SliceT1Read
 from database.schemas.slice_t2 import SliceT2Input, SliceT2Read
@@ -19,6 +20,7 @@ from database.services.persons import PersonsService
 from database.services.soba import SobaService
 from database.services.stopbang import StopBangService
 from database.services.las_vegas import LasVegasService
+from database.services.qor15 import Qor15Service
 from database.services.slice_t0 import SliceT0Service
 from database.services.slice_t1 import SliceT1Service
 from database.services.slice_t2 import SliceT2Service
@@ -187,6 +189,27 @@ def lv_upsert_result(person_id: int, data: LasVegasInput) -> LasVegasRead:
 def lv_clear_result(person_id: int) -> bool:
     with SessionLocal() as session:
         svc = LasVegasService(session)
+        return svc.clear_result(person_id)
+
+
+def qor15_get_result(person_id: int) -> Qor15Read | None:
+    with SessionLocal() as session:
+        svc = Qor15Service(session)
+        try:
+            return svc.get_result(person_id)
+        except NotFoundError:
+            return None
+
+
+def qor15_upsert_result(person_id: int, data: Qor15Input) -> Qor15Read:
+    with SessionLocal() as session:
+        svc = Qor15Service(session)
+        return svc.upsert_result(person_id, data)
+
+
+def qor15_clear_result(person_id: int) -> bool:
+    with SessionLocal() as session:
+        svc = Qor15Service(session)
         return svc.clear_result(person_id)
 
 

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -117,6 +117,7 @@ class PersonScales(Base):
     lee_rcri_filled = Column(Boolean, nullable=False, default=False)
     caprini_filled = Column(Boolean, nullable=False, default=False)
     las_vegas_filled = Column(Boolean, nullable=False, default=False)
+    qor15_filled = Column(Boolean, nullable=False, default=False)
 
     # Технические поля
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -153,6 +154,10 @@ class PersonScales(Base):
         "LasVegasResult", back_populates="scales",
         uselist=False, cascade="all, delete-orphan"
     )
+    qor15 = relationship(
+        "Qor15Result", back_populates="scales",
+        uselist=False, cascade="all, delete-orphan",
+    )
 
     def __repr__(self):
         return (
@@ -163,7 +168,8 @@ class PersonScales(Base):
             f"soba={self.soba_filled}, "
             f"lee_rcri={self.lee_rcri_filled}, "
             f"caprini={self.caprini_filled}, "
-            f"las_vegas={self.las_vegas_filled})>"
+            f"las_vegas={self.las_vegas_filled}, "
+            f"qor15={self.qor15_filled})>"
         )
 
 
@@ -1647,3 +1653,38 @@ class LasVegasResult(Base):
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
     scales = relationship("PersonScales", back_populates="las_vegas")
+
+
+class Qor15Result(Base):
+    __tablename__ = "qor15_results"
+    __table_args__ = (UniqueConstraint("scales_id", name="uq_qor15_scales"),)
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    scales_id = Column(
+        Integer, ForeignKey("person_scales.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    q1 = Column(SmallInteger, nullable=False, default=0)
+    q2 = Column(SmallInteger, nullable=False, default=0)
+    q3 = Column(SmallInteger, nullable=False, default=0)
+    q4 = Column(SmallInteger, nullable=False, default=0)
+    q5 = Column(SmallInteger, nullable=False, default=0)
+    q6 = Column(SmallInteger, nullable=False, default=0)
+    q7 = Column(SmallInteger, nullable=False, default=0)
+    q8 = Column(SmallInteger, nullable=False, default=0)
+    q9 = Column(SmallInteger, nullable=False, default=0)
+    q10 = Column(SmallInteger, nullable=False, default=0)
+    q11 = Column(SmallInteger, nullable=False, default=0)
+    q12 = Column(SmallInteger, nullable=False, default=0)
+    q13 = Column(SmallInteger, nullable=False, default=0)
+    q14 = Column(SmallInteger, nullable=False, default=0)
+    q15 = Column(SmallInteger, nullable=False, default=0)
+
+    total_score = Column(Integer, nullable=False, default=0)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    scales = relationship("PersonScales", back_populates="qor15")

--- a/src/database/repositories/qor15.py
+++ b/src/database/repositories/qor15.py
@@ -1,0 +1,22 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import select, delete
+
+from database.models import Qor15Result
+
+
+class Qor15Repository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def get_by_scales_id(self, scales_id: int) -> Qor15Result | None:
+        stmt = select(Qor15Result).where(Qor15Result.scales_id == scales_id)
+        return self.session.execute(stmt).scalar_one_or_none()
+
+    def add(self, obj: Qor15Result) -> Qor15Result:
+        self.session.add(obj)
+        return obj
+
+    def delete_by_scales_id(self, scales_id: int) -> int:
+        stmt = delete(Qor15Result).where(Qor15Result.scales_id == scales_id)
+        res = self.session.execute(stmt)
+        return res.rowcount or 0

--- a/src/database/schemas/qor15.py
+++ b/src/database/schemas/qor15.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class Qor15Input(BaseModel):
+    q1: int = Field(..., ge=0, le=10)
+    q2: int = Field(..., ge=0, le=10)
+    q3: int = Field(..., ge=0, le=10)
+    q4: int = Field(..., ge=0, le=10)
+    q5: int = Field(..., ge=0, le=10)
+    q6: int = Field(..., ge=0, le=10)
+    q7: int = Field(..., ge=0, le=10)
+    q8: int = Field(..., ge=0, le=10)
+    q9: int = Field(..., ge=0, le=10)
+    q10: int = Field(..., ge=0, le=10)
+    q11: int = Field(..., ge=0, le=10)
+    q12: int = Field(..., ge=0, le=10)
+    q13: int = Field(..., ge=0, le=10)
+    q14: int = Field(..., ge=0, le=10)
+    q15: int = Field(..., ge=0, le=10)
+
+
+class Qor15Read(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    scales_id: int
+    q1: int
+    q2: int
+    q3: int
+    q4: int
+    q5: int
+    q6: int
+    q7: int
+    q8: int
+    q9: int
+    q10: int
+    q11: int
+    q12: int
+    q13: int
+    q14: int
+    q15: int
+    total_score: int

--- a/src/database/services/qor15.py
+++ b/src/database/services/qor15.py
@@ -1,0 +1,56 @@
+from sqlalchemy.orm import Session
+
+from database.models import PersonScales, Qor15Result
+from database.repositories.person_scales import PersonScalesRepository
+from database.repositories.qor15 import Qor15Repository
+from database.schemas.qor15 import Qor15Input, Qor15Read
+from database.services.utils import NotFoundError
+
+
+class Qor15Service:
+    """Upsert/get/clear QoR-15 and update flag in PersonScales."""
+
+    def __init__(self, session: Session):
+        self.session = session
+        self.ps_repo = PersonScalesRepository(session)
+        self.repo = Qor15Repository(session)
+
+    def _get_or_create_ps(self, person_id: int) -> PersonScales:
+        return self.ps_repo.get_or_create_for_person(person_id)
+
+    def upsert_result(self, person_id: int, data: Qor15Input) -> Qor15Read:
+        ps = self._get_or_create_ps(person_id)
+        res = self.repo.get_by_scales_id(ps.id)
+        if res is None:
+            res = Qor15Result(scales_id=ps.id)
+            self.repo.add(res)
+
+        for i in range(1, 16):
+            setattr(res, f"q{i}", int(getattr(data, f"q{i}")))
+        res.total_score = sum(getattr(res, f"q{i}") for i in range(1, 16))
+
+        self.ps_repo.update_fields(ps, qor15_filled=True)
+
+        self.session.commit()
+        self.session.refresh(res)
+        self.session.refresh(ps)
+        return Qor15Read.model_validate(res)
+
+    def clear_result(self, person_id: int) -> bool:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if not ps:
+            raise NotFoundError("PersonScales not found")
+        affected = self.repo.delete_by_scales_id(ps.id)
+        if affected:
+            self.ps_repo.update_fields(ps, qor15_filled=False)
+        self.session.commit()
+        return bool(affected)
+
+    def get_result(self, person_id: int) -> Qor15Read:
+        ps = self.ps_repo.get_by_person_id(person_id)
+        if not ps:
+            raise NotFoundError("PersonScales not found")
+        res = self.repo.get_by_scales_id(ps.id)
+        if not res:
+            raise NotFoundError("Qor15Result not found")
+        return Qor15Read.model_validate(res)

--- a/src/frontend/patient.py
+++ b/src/frontend/patient.py
@@ -430,6 +430,7 @@ def preoperative_exam():
         ("Рекомендации SOBA — план ведения при ожирении", "show_soba_scale", "soba_filled", "soba"),
         ("Индекс Lee (RCRI) — оценка кардиального риска", "show_lee_scale", "lee_rcri_filled", "lee_rcri"),
         ("Шкала Caprini — оценка риска ВТЭО", "show_caprini_scale", "caprini_filled", "caprini"),
+        ("Шкала QoR-15 — качество восстановления", "show_qor15_scale", "qor15_filled", "qor15"),
     ]
 
     for i, (label, item, status_field, rel_field) in enumerate(scales):

--- a/src/frontend/scales/qor15.py
+++ b/src/frontend/scales/qor15.py
@@ -1,0 +1,50 @@
+import streamlit as st
+
+from database.functions import qor15_get_result, qor15_upsert_result, get_person
+from database.schemas.qor15 import Qor15Input
+from frontend.components import create_big_button
+from frontend.utils import change_menu_item
+
+QUESTIONS = [
+    ("q1", "Способность легко дышать"),
+    ("q2", "Способность получать удовольствие от еды"),
+    ("q3", "Ощущение себя отдохнувшим"),
+    ("q4", "Наличие хорошего сна"),
+    ("q5", "Способность соблюдать личную гигиену без посторонней помощи"),
+    ("q6", "Способность общаться с семьей или друзьями"),
+    ("q7", "Получение поддержки от врачей и со стороны сестринского персонала"),
+    ("q8", "Способность вернуться к работе или обычным домашним делам"),
+    ("q9", "Ощущение комфорта и что всё под контролем"),
+    ("q10", "Ощущение, что всё благополучно"),
+    ("q11", "Умеренная боль"),
+    ("q12", "Сильная боль"),
+    ("q13", "Тошнота или рвота"),
+    ("q14", "Чувство тревоги или беспокойства"),
+    ("q15", "Чувство печали или подавленности"),
+]
+
+
+def show_qor15_scale():
+    person = st.session_state.get("current_patient_info")
+    if not person:
+        st.error("Пациент не выбран.")
+        return
+
+    st.subheader("Шкала QoR-15")
+
+    stored = qor15_get_result(person.id)
+    if stored:
+        st.info(f"Текущие данные: баллы **{stored.total_score}**")
+
+    with st.form("qor15_form"):
+        values = {}
+        for field, label in QUESTIONS:
+            values[field] = st.number_input(label, min_value=0, max_value=10, value=int(getattr(stored, field, 0)), step=1)
+        submitted = st.form_submit_button("💾 Сохранить", width='stretch')
+
+    if submitted:
+        data = Qor15Input(**values)
+        saved = qor15_upsert_result(person.id, data)
+        st.success(f"Сохранено. Баллы: **{saved.total_score}**")
+        st.session_state["current_patient_info"] = get_person(person.id)
+    create_big_button("⬅️ Назад", on_click=change_menu_item, kwargs={"item": "preoperative_exam"}, key="back_btn")

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from frontend.scales.lee import show_lee_scale
 from frontend.scales.soba import show_soba_scale
 from frontend.scales.stopbang import show_stopbang_scale
 from frontend.scales.las_vegas import show_las_vegas_scale
+from frontend.scales.qor15 import show_qor15_scale
 from frontend.component.loader import export_patient_data
 from frontend.operation import show_operation, show_postoperative, show_operation_point
 from frontend.t0 import show_t0_slice
@@ -55,6 +56,7 @@ menu_items = {
     "show_lee_scale": show_lee_scale,
     "show_caprini_scale": show_caprini_scale,
     "show_las_vegas_scale": show_las_vegas_scale,
+    "show_qor15_scale": show_qor15_scale,
     "show_t0_slice": show_t0_slice,
     "show_t1_slice": show_t1_slice,
     "show_t2_slice": show_t2_slice,


### PR DESCRIPTION
## Summary
- add QoR-15 scale storage and flag to person scales
- implement QoR-15 repository, service and database functions
- add QoR-15 form and menu entry for preoperative exam

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5e4af76c48327b6c38ef2f9fd3200