### PR TITLE
feat: export additional scales

### DIFF
--- a/src/frontend/component/loader.py
+++ b/src/frontend/component/loader.py
@@ -48,6 +48,12 @@ def _caprini_label(level):
     return ["Очень низкий", "Низкий", "Умеренный", "Высокий", "Очень высокий"][max(0, min(4, int(level)))]
 
 
+def _las_vegas_label(level):
+    if level is None:
+        return "—"
+    return ["Низкий", "Промежуточный", "Высокий"][max(0, min(2, int(level)))]
+
+
 def _rcri_risk(score):
     if score is None: return "—"
     if score == 0: return "≈0.4%"
@@ -77,6 +83,11 @@ def export_patient_data():
     soba = _safe(db_funcs.get_soba, person.id, label="SOBA")  # -> SobaRead | None
     rcri = _safe(db_funcs.rcri_get_result, person.id, label="RCRI")  # -> LeeRcriRead | None
     cap = _safe(db_funcs.caprini_get_result, person.id, label="Caprini")  # -> CapriniRead | None
+    lv = _safe(db_funcs.lv_get_result, person.id, label="Las Vegas")
+    qor = _safe(db_funcs.qor15_get_result, person.id, label="QoR-15")
+    ald = _safe(db_funcs.ald_get_result, person.id, label="Aldrete")
+    mmse_t0 = _safe(db_funcs.mmse_get_result, person.id, 0, label="MMSE t0")
+    mmse_t10 = _safe(db_funcs.mmse_get_result, person.id, 10, label="MMSE t10")
 
     # 2b) Подтягиваем все срезы динамически (T0…T12)
     slices_data = []
@@ -149,6 +160,21 @@ def export_patient_data():
     add_scale("Caprini", cap)
     if cap is not None:
         row["Caprini: риск"] = _caprini_label(cap.risk_level)
+
+    # Las Vegas
+    add_scale("Las Vegas", lv)
+    if lv is not None:
+        row["Las Vegas: риск"] = _las_vegas_label(getattr(lv, "risk_level", None))
+
+    # QoR-15
+    add_scale("QoR-15", qor)
+
+    # Aldrete
+    add_scale("Aldrete", ald)
+
+    # MMSE
+    add_scale("MMSE t0", mmse_t0)
+    add_scale("MMSE t10", mmse_t10)
 
     # 4) Добавляем все поля срезов в основную строку
     for name, data, schema in slices_data:

--- a/src/frontend/patient.py
+++ b/src/frontend/patient.py
@@ -61,6 +61,12 @@ def _caprini_label(level):
     ][max(0, min(4, int(level)))]
 
 
+def _las_vegas_label(level):
+    if level is None:
+        return "—"
+    return ["Низкий", "Промежуточный", "Высокий"][max(0, min(2, int(level)))]
+
+
 def _rcri_risk(score):
     if score is None:
         return "—"
@@ -251,6 +257,11 @@ def export_patients():
         "SOBA": "SOBA",
         "RCRI": "RCRI",
         "Caprini": "Caprini",
+        "LasVegas": "Las Vegas",
+        "QoR-15": "QoR-15",
+        "Aldrete": "Aldrete",
+        "MMSE_t0": "MMSE t0",
+        "MMSE_t10": "MMSE t10",
     }
 
     slices = {
@@ -351,6 +362,27 @@ def export_patients():
                 cap = _safe(db_funcs.caprini_get_result, person.id, label="Caprini")
                 row["Caprini: сумма"] = getattr(cap, "total_score", None)
                 row["Caprini: риск"] = _caprini_label(getattr(cap, "risk_level", None))
+
+            if "LasVegas" in selected_scales:
+                lv = _safe(db_funcs.lv_get_result, person.id, label="Las Vegas")
+                row["Las Vegas: сумма"] = getattr(lv, "total_score", None)
+                row["Las Vegas: риск"] = _las_vegas_label(getattr(lv, "risk_level", None))
+
+            if "QoR-15" in selected_scales:
+                qor = _safe(db_funcs.qor15_get_result, person.id, label="QoR-15")
+                row["QoR-15: сумма"] = getattr(qor, "total_score", None)
+
+            if "Aldrete" in selected_scales:
+                ald = _safe(db_funcs.ald_get_result, person.id, label="Aldrete")
+                row["Aldrete: сумма"] = getattr(ald, "total_score", None)
+
+            if "MMSE_t0" in selected_scales:
+                mm0 = _safe(db_funcs.mmse_get_result, person.id, 0, label="MMSE t0")
+                row["MMSE t0: сумма"] = getattr(mm0, "total_score", None)
+
+            if "MMSE_t10" in selected_scales:
+                mm10 = _safe(db_funcs.mmse_get_result, person.id, 10, label="MMSE t10")
+                row["MMSE t10: сумма"] = getattr(mm10, "total_score", None)
 
             for slice_key in selected_slices:
                 data = _safe(slices[slice_key], person.id, label=f"срез {slice_key}")

--- a/src/frontend/scales/mmse.py
+++ b/src/frontend/scales/mmse.py
@@ -91,6 +91,7 @@ def _show_form(timepoint: int, back_item: str, title: str):
             for field, label in items:
                 key = f"{field}_{timepoint}"
                 values[field] = st.checkbox(label, key=key)
+            st.write("")
         submitted = st.form_submit_button("💾 Сохранить", width='stretch')
 
     if submitted:


### PR DESCRIPTION
## Summary
- extend patient and global exports with Las Vegas, QoR-15, Aldrete, and MMSE scales
- improve MMSE form layout by adding spacing between groups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5ed95db58832791f720efa3e45618