### PR TITLE
feat: allow selective patient table export

### DIFF
--- a/src/frontend/component/loader.py
+++ b/src/frontend/component/loader.py
@@ -48,6 +48,12 @@ def _caprini_label(level):
     return ["Очень низкий", "Низкий", "Умеренный", "Высокий", "Очень высокий"][max(0, min(4, int(level)))]
 
 
+def _las_vegas_label(level):
+    if level is None:
+        return "—"
+    return ["Низкий", "Промежуточный", "Высокий"][max(0, min(2, int(level)))]
+
+
 def _rcri_risk(score):
     if score is None: return "—"
     if score == 0: return "≈0.4%"
@@ -71,12 +77,21 @@ def export_patient_data():
         return
 
     # 2) Подтягиваем все шкалы (каждый вызов безопасный)
+    from database.schemas.elganzouri import ElGanzouriRead
+    from database.schemas.ariscat import AriscatRead
+    from database.schemas.stopbang import StopBangRead
+
     elg = _safe(db_funcs.elg_get_result, person.id, label="El-Ganzouri")  # -> ElGanzouriRead | None
     ar = _safe(db_funcs.ar_get_result, person.id, label="ARISCAT")  # -> AriscatRead | None
     sb = _safe(db_funcs.sb_get_result, person.id, label="STOP-BANG")  # -> StopBangRead | None
     soba = _safe(db_funcs.get_soba, person.id, label="SOBA")  # -> SobaRead | None
     rcri = _safe(db_funcs.rcri_get_result, person.id, label="RCRI")  # -> LeeRcriRead | None
     cap = _safe(db_funcs.caprini_get_result, person.id, label="Caprini")  # -> CapriniRead | None
+    lv = _safe(db_funcs.lv_get_result, person.id, label="Las Vegas")
+    qor = _safe(db_funcs.qor15_get_result, person.id, label="QoR-15")
+    ald = _safe(db_funcs.ald_get_result, person.id, label="Aldrete")
+    mmse_t0 = _safe(db_funcs.mmse_get_result, person.id, 0, label="MMSE t0")
+    mmse_t10 = _safe(db_funcs.mmse_get_result, person.id, 10, label="MMSE t10")
 
     # 2b) Подтягиваем все срезы динамически (T0…T12)
     slices_data = []
@@ -93,7 +108,7 @@ def export_patient_data():
 
     atype = g(person, "anesthesia_type", None)
 
-    row = {
+    base_info = {
         "patient_id": person.id,
         "№ карты": g(person, "card_number", ""),
         "Фамилия": g(person, "last_name", ""),
@@ -108,68 +123,91 @@ def export_patient_data():
         "ИМТ": _bmi(g(person, "weight", None), g(person, "height", None)),
     }
 
-    def add_scale(prefix, obj):
-        if obj is None:
-            return
-        data = obj.model_dump()
-        data.pop("id", None)
-        data.pop("scales_id", None)
-        score = data.pop("total_score", None)
-        if score is not None:
-            row[f"{prefix}: сумма"] = score
-        for field, value in data.items():
-            row[f"{prefix}: {field}"] = value
+    row_scales = dict(base_info)
+    row_slices = dict(base_info)
+
+    def add_scale(row, prefix, obj, schema):
+        fields = [
+            f for f in schema.model_fields
+            if f not in {"id", "scales_id", "total_score", "risk_level"}
+        ]
+        for field in fields:
+            row[f"{prefix}: {field}"] = getattr(obj, field, None) if obj else None
+        row[f"{prefix}: сумма"] = getattr(obj, "total_score", None) if obj else None
+
+    EmptySchema = type("EmptySchema", (), {"model_fields": {}})
 
     # El-Ganzouri
-    add_scale("ELG", elg)
+    add_scale(row_scales, "ELG", elg, ElGanzouriRead)
     if elg is not None:
-        row["ELG: рекомендация"] = _elg_plan(elg.total_score)
+        row_scales["ELG: рекомендация"] = _elg_plan(elg.total_score)
 
     # ARISCAT
-    add_scale("ARISCAT", ar)
+    add_scale(row_scales, "ARISCAT", ar, AriscatRead)
 
     # STOP-BANG
-    add_scale("STOP-BANG", sb)
+    add_scale(row_scales, "STOP-BANG", sb, StopBangRead)
     if sb is not None:
-        row["STOP-BANG: риск"] = _stopbang_label(sb.risk_level)
+        row_scales["STOP-BANG: риск"] = _stopbang_label(sb.risk_level)
 
     # SOBA
-    add_scale("SOBA", soba)
+    add_scale(row_scales, "SOBA", soba, type(soba) if soba else EmptySchema)
     if soba is not None:
-        row["SOBA: STOP-BANG риск (кэш)"] = _stopbang_label(
+        row_scales["SOBA: STOP-BANG риск (кэш)"] = _stopbang_label(
             getattr(soba, "stopbang_risk_cached", None)
         )
 
     # Lee RCRI
-    add_scale("RCRI", rcri)
+    add_scale(row_scales, "RCRI", rcri, type(rcri) if rcri else EmptySchema)
     if rcri is not None:
-        row["RCRI: риск (частота осложнений)"] = _rcri_risk(rcri.total_score)
+        row_scales["RCRI: риск (частота осложнений)"] = _rcri_risk(rcri.total_score)
 
     # Caprini
-    add_scale("Caprini", cap)
+    add_scale(row_scales, "Caprini", cap, type(cap) if cap else EmptySchema)
     if cap is not None:
-        row["Caprini: риск"] = _caprini_label(cap.risk_level)
+        row_scales["Caprini: риск"] = _caprini_label(cap.risk_level)
 
-    # 4) Добавляем все поля срезов в основную строку
+    # Las Vegas
+    add_scale(row_scales, "Las Vegas", lv, type(lv) if lv else EmptySchema)
+    if lv is not None:
+        row_scales["Las Vegas: риск"] = _las_vegas_label(getattr(lv, "risk_level", None))
+
+    # QoR-15
+    add_scale(row_scales, "QoR-15", qor, type(qor) if qor else EmptySchema)
+
+    # Aldrete
+    add_scale(row_scales, "Aldrete", ald, type(ald) if ald else EmptySchema)
+
+    # MMSE
+    add_scale(row_scales, "MMSE t0", mmse_t0, type(mmse_t0) if mmse_t0 else EmptySchema)
+    add_scale(row_scales, "MMSE t10", mmse_t10, type(mmse_t10) if mmse_t10 else EmptySchema)
+
+    # 4) Добавляем все поля срезов
     for name, data, schema in slices_data:
         for field in schema.model_fields.keys():
-            row[f"{name}: {field}"] = getattr(data, field, None) if data is not None else None
+            row_slices[f"{name}: {field}"] = getattr(data, field, None) if data is not None else None
 
     # 5) Покажем и дадим скачать
-    df = pd.DataFrame([row])
-    df.replace({True: 1, False: 0}, inplace=True)
-    st.markdown("### Предпросмотр")
-    st.dataframe(df, width="stretch")
+    df_scales = pd.DataFrame([row_scales])
+    df_slices = pd.DataFrame([row_slices])
+    df_scales.replace({True: 1, False: 0}, inplace=True)
+    df_slices.replace({True: 1, False: 0}, inplace=True)
+    st.markdown("### Предпросмотр шкал")
+    st.dataframe(df_scales, width="stretch")
+    st.markdown("### Предпросмотр срезов")
+    st.dataframe(df_slices, width="stretch")
 
     excel_buf = io.BytesIO()
-    df.to_excel(excel_buf, index=False)
+    with pd.ExcelWriter(excel_buf, engine="openpyxl") as writer:
+        df_scales.to_excel(writer, index=False, sheet_name="Шкалы")
+        df_slices.to_excel(writer, index=False, sheet_name="Срезы")
 
     st.download_button(
         "⬇️ Скачать Excel",
         data=excel_buf.getvalue(),
         file_name=f"patient_{person.id}_export.xlsx",
         mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        width="stretch",
+        use_container_width=True,
     )
 
     st.caption(

--- a/src/frontend/patient.py
+++ b/src/frontend/patient.py
@@ -1,9 +1,11 @@
 import io
 import time
 from datetime import date
+from importlib import import_module
 
 import pandas as pd
 import streamlit as st
+from functools import reduce
 
 import database.functions as db_funcs
 from database.functions import get_person, create_person, search_persons
@@ -59,6 +61,12 @@ def _caprini_label(level):
         "Высокий",
         "Очень высокий",
     ][max(0, min(4, int(level)))]
+
+
+def _las_vegas_label(level):
+    if level is None:
+        return "—"
+    return ["Низкий", "Промежуточный", "Высокий"][max(0, min(2, int(level)))]
 
 
 def _rcri_risk(score):
@@ -244,138 +252,134 @@ def find_patient():
 def export_patients():
     st.title("📤 Выгрузка всех пациентов")
 
-    scales = {
-        "ELG": "El-Ganzouri",
-        "ARISCAT": "ARISCAT",
-        "STOP-BANG": "STOP-BANG",
-        "SOBA": "SOBA",
-        "RCRI": "RCRI",
-        "Caprini": "Caprini",
+    scale_map = {
+        "El-Ganzouri": ("elg", lambda pid: db_funcs.elg_get_result(pid)),
+        "ARISCAT": ("ariscat", lambda pid: db_funcs.ar_get_result(pid)),
+        "STOP-BANG": ("stopbang", lambda pid: db_funcs.sb_get_result(pid)),
+        "SOBA": ("soba", lambda pid: db_funcs.get_soba(pid)),
+        "RCRI": ("rcri", lambda pid: db_funcs.rcri_get_result(pid)),
+        "Caprini": ("caprini", lambda pid: db_funcs.caprini_get_result(pid)),
+        "Las Vegas": ("las_vegas", lambda pid: db_funcs.lv_get_result(pid)),
+        "QoR-15": ("qor15", lambda pid: db_funcs.qor15_get_result(pid)),
+        "Aldrete": ("aldrete", lambda pid: db_funcs.ald_get_result(pid)),
+        "MMSE t0": ("mmse_t0", lambda pid: db_funcs.mmse_get_result(pid, 0)),
+        "MMSE t10": ("mmse_t10", lambda pid: db_funcs.mmse_get_result(pid, 10)),
     }
+    slice_map = {f"T{i}": (f"t{i}", getattr(db_funcs, f"t{i}_get_result")) for i in range(13)}
 
-    slices = {
-        "T0": db_funcs.t0_get_result,
-        "T1": db_funcs.t1_get_result,
-        "T2": db_funcs.t2_get_result,
-        "T3": db_funcs.t3_get_result,
-        "T4": db_funcs.t4_get_result,
-        "T5": db_funcs.t5_get_result,
-        "T6": db_funcs.t6_get_result,
-        "T7": db_funcs.t7_get_result,
-        "T8": db_funcs.t8_get_result,
-        "T9": db_funcs.t9_get_result,
-        "T10": db_funcs.t10_get_result,
-        "T11": db_funcs.t11_get_result,
-        "T12": db_funcs.t12_get_result,
-    }
-
-    def _select_all():
-        for k in scales:
-            st.session_state[f"scale_{k}"] = True
-        for k in slices:
-            st.session_state[f"slice_{k}"] = True
-
-    st.checkbox("Выгрузить всё", key="export_all_db", on_change=_select_all)
-
-    col_scales, col_slices = st.columns(2)
-    with col_scales:
-        st.markdown("#### Шкалы")
-        for key, label in scales.items():
-            st.checkbox(label, key=f"scale_{key}")
-
-    with col_slices:
-        st.markdown("#### Срезы")
-        for key in slices:
-            st.checkbox(key, key=f"slice_{key}")
+    table_labels = ["Пациенты", "Статусы шкал"] + list(scale_map.keys()) + list(slice_map.keys())
+    select_all = st.checkbox("Отметить все")
+    selected = st.multiselect(
+        "Выберите таблицы для выгрузки",
+        table_labels,
+        default=table_labels if select_all else [],
+    )
+    if select_all:
+        selected = table_labels
 
     if st.button("Сформировать выгрузку", use_container_width=True):
-        selected_scales = [k for k in scales if st.session_state.get(f"scale_{k}")]
-        selected_slices = [k for k in slices if st.session_state.get(f"slice_{k}")]
-
-        if not selected_scales and not selected_slices:
-            st.warning("Выберите хотя бы одну шкалу или срез.")
-            return
-
         persons = search_persons(limit=100000)
-        rows = []
-        for person in persons:
-            atype = getattr(person, "anesthesia_type", None)
-            row = {
-                "patient_id": person.id,
-                "№ карты": getattr(person, "card_number", ""),
-                "Фамилия": getattr(person, "last_name", ""),
-                "Имя": getattr(person, "first_name", ""),
-                "Отчество": getattr(person, "patronymic", ""),
-                "Дата включения": getattr(person, "inclusion_date", None),
-                "Тип анестезии": atype.value if atype else "",
-                "Возраст (лет)": getattr(person, "age", None),
-                "Рост (см)": getattr(person, "height", None),
-                "Вес (кг)": getattr(person, "weight", None),
-                "Пол": "Ж" if bool(getattr(person, "gender", False)) else "М",
-                "ИМТ": _bmi(getattr(person, "weight", None), getattr(person, "height", None)),
-            }
-
-            if "ELG" in selected_scales:
-                elg = _safe(db_funcs.elg_get_result, person.id, label="El-Ganzouri")
-                score = getattr(elg, "total_score", None)
-                row["ELG: сумма"] = score
-                row["ELG: рекомендация"] = _elg_plan(score)
-
-            if "ARISCAT" in selected_scales:
-                ar = _safe(db_funcs.ar_get_result, person.id, label="ARISCAT")
-                row["ARISCAT: сумма"] = getattr(ar, "total_score", None)
-
-            if "STOP-BANG" in selected_scales:
-                sb = _safe(db_funcs.sb_get_result, person.id, label="STOP-BANG")
-                row["STOP-BANG: сумма"] = getattr(sb, "total_score", None)
-                row["STOP-BANG: риск"] = _stopbang_label(getattr(sb, "risk_level", None))
-
-            if "SOBA" in selected_scales:
-                soba = _safe(db_funcs.get_soba, person.id, label="SOBA")
-                row["SOBA: STOP-BANG сумма (кэш)"] = getattr(soba, "stopbang_score_cached", None)
-                row["SOBA: STOP-BANG риск (кэш)"] = _stopbang_label(getattr(soba, "stopbang_risk_cached", None))
-                row["SOBA: плохая ФН"] = getattr(soba, "poor_functional_status", None)
-                row["SOBA: изменения ЭКГ"] = getattr(soba, "ekg_changes", None)
-                row["SOBA: неконтр. АГ/ИБС"] = getattr(soba, "uncontrolled_htn_ihd", None)
-                row["SOBA: SpO₂<94%"] = getattr(soba, "spo2_room_air_lt_94", None)
-                row["SOBA: PaCO₂>28"] = getattr(soba, "hypercapnia_co2_gt_28", None)
-                row["SOBA: ТГВ/ТЭЛА анамнез"] = getattr(soba, "vte_history", None)
-
-            if "RCRI" in selected_scales:
-                rcri = _safe(db_funcs.rcri_get_result, person.id, label="RCRI")
-                score = getattr(rcri, "total_score", None)
-                row["RCRI: сумма"] = score
-                row["RCRI: риск (частота осложнений)"] = _rcri_risk(score)
-
-            if "Caprini" in selected_scales:
-                cap = _safe(db_funcs.caprini_get_result, person.id, label="Caprini")
-                row["Caprini: сумма"] = getattr(cap, "total_score", None)
-                row["Caprini: риск"] = _caprini_label(getattr(cap, "risk_level", None))
-
-            for slice_key in selected_slices:
-                data = _safe(slices[slice_key], person.id, label=f"срез {slice_key}")
-                if data is not None:
-                    d = data.model_dump()
-                    d.pop("id", None)
-                    d.pop("slices_id", None)
-                    for field, value in d.items():
-                        row[f"{slice_key}: {field}"] = value
-
-            rows.append(row)
-
-        if not rows:
+        if not persons:
             st.info("Нет данных для экспорта.")
             return
 
-        df = pd.DataFrame(rows)
-        df.replace({True: 1, False: 0}, inplace=True)
-        st.markdown("### Предпросмотр")
-        st.dataframe(df, width="stretch")
+        base_df = pd.DataFrame({"patient_id": [p.id for p in persons]})
+        dfs_scales = [base_df]
+        dfs_slices = [base_df.copy()]
+
+        if "Пациенты" in selected:
+            patient_rows = []
+            for person in persons:
+                atype = getattr(person, "anesthesia_type", None)
+                patient_rows.append(
+                    {
+                        "patient_id": person.id,
+                        "card_number": getattr(person, "card_number", ""),
+                        "last_name": getattr(person, "last_name", ""),
+                        "first_name": getattr(person, "first_name", ""),
+                        "patronymic": getattr(person, "patronymic", ""),
+                        "inclusion_date": getattr(person, "inclusion_date", None),
+                        "anesthesia_type": atype.value if atype else "",
+                        "age": getattr(person, "age", None),
+                        "height": getattr(person, "height", None),
+                        "weight": getattr(person, "weight", None),
+                        "gender": "Ж" if bool(getattr(person, "gender", False)) else "М",
+                        "bmi": _bmi(getattr(person, "weight", None), getattr(person, "height", None)),
+                    }
+                )
+            patient_df = pd.DataFrame(patient_rows)
+            dfs_scales.append(patient_df)
+            dfs_slices.append(patient_df.copy())
+
+        if "Статусы шкал" in selected:
+            status_rows = []
+            for person in persons:
+                full = _safe(get_person, person.id, label="карточки пациента")
+                sc = getattr(full, "scales", None) if full else None
+                row = {"patient_id": person.id}
+                if sc:
+                    for field in [
+                        "el_ganzouri_filled",
+                        "ariscat_filled",
+                        "stopbang_filled",
+                        "soba_filled",
+                        "lee_rcri_filled",
+                        "caprini_filled",
+                        "las_vegas_filled",
+                        "aldrete_filled",
+                        "mmse_t0_filled",
+                        "mmse_t10_filled",
+                        "qor15_filled",
+                    ]:
+                        row[field] = bool(getattr(sc, field, False))
+                status_rows.append(row)
+            dfs_scales.append(pd.DataFrame(status_rows))
+
+        for label, (prefix, getter) in scale_map.items():
+            if label not in selected:
+                continue
+            rows = []
+            for person in persons:
+                res = _safe(getter, person.id, label=label)
+                row = {"patient_id": person.id}
+                if res is not None:
+                    data = res.model_dump()
+                    data.pop("id", None)
+                    data.pop("scales_id", None)
+                    for k, v in data.items():
+                        row[f"{prefix}_{k}"] = v
+                rows.append(row)
+            dfs_scales.append(pd.DataFrame(rows))
+
+        for label, (prefix, getter) in slice_map.items():
+            if label not in selected:
+                continue
+            rows = []
+            schema_module = import_module(f"database.schemas.slice_{prefix}")
+            schema_cls = getattr(schema_module, f"Slice{prefix.upper()}Input")
+            fields = list(schema_cls.model_fields.keys())
+            for person in persons:
+                res = _safe(getter, person.id, label=f"срез {label}")
+                row = {"patient_id": person.id}
+                for f in fields:
+                    row[f"{prefix}_{f}"] = getattr(res, f, None) if res is not None else None
+                rows.append(row)
+            dfs_slices.append(pd.DataFrame(rows))
+
+        df_scales = reduce(lambda l, r: pd.merge(l, r, on="patient_id", how="left"), dfs_scales)
+        df_slices = reduce(lambda l, r: pd.merge(l, r, on="patient_id", how="left"), dfs_slices)
+        df_scales.replace({True: 1, False: 0}, inplace=True)
+        df_slices.replace({True: 1, False: 0}, inplace=True)
+
+        st.markdown("### Предпросмотр шкал")
+        st.dataframe(df_scales, width="stretch")
+        st.markdown("### Предпросмотр срезов")
+        st.dataframe(df_slices, width="stretch")
 
         buf = io.BytesIO()
-        with pd.ExcelWriter(buf) as writer:
-            df.to_excel(writer, index=False, sheet_name="Пациенты")
-
+        with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+            df_scales.to_excel(writer, index=False, sheet_name="Шкалы")
+            df_slices.to_excel(writer, index=False, sheet_name="Срезы")
         st.download_button(
             "⬇️ Скачать Excel",
             data=buf.getvalue(),

--- a/src/frontend/scales/mmse.py
+++ b/src/frontend/scales/mmse.py
@@ -91,6 +91,7 @@ def _show_form(timepoint: int, back_item: str, title: str):
             for field, label in items:
                 key = f"{field}_{timepoint}"
                 values[field] = st.checkbox(label, key=key)
+            st.write("")
         submitted = st.form_submit_button("💾 Сохранить", width='stretch')
 
     if submitted:


### PR DESCRIPTION
## Summary
- split single-patient Excel export into separate "Шкалы" and "Срезы" sheets
- export-all workflow now writes scale and slice tables to distinct workbook sheets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5ed95db58832791f720efa3e45618